### PR TITLE
feat: Telegram ChatOps bot for DCN Network Tool

### DIFF
--- a/src/telegram_bot/.env.example
+++ b/src/telegram_bot/.env.example
@@ -16,7 +16,11 @@ TELEGRAM_ADMIN_CHAT_IDS=
 # Where the DCN Network Tool API is reachable (same default as mcp_dcn_server.py).
 DCN_API_URL=http://localhost:5757
 
-# Per-chat rate limit (messages per 60s) and HTTP timeouts (seconds).
+# Per-chat rate limit (messages per 60s). Set to 0 to disable rate limiting.
 TELEGRAM_RATE_LIMIT_PER_MIN=20
+
+# HTTP timeouts (seconds): general requests, /ask (LLM), and long-running
+# report/incident collection.
 TELEGRAM_REQUEST_TIMEOUT=30
 TELEGRAM_ASK_TIMEOUT=120
+TELEGRAM_REPORT_TIMEOUT=300

--- a/src/telegram_bot/.env.example
+++ b/src/telegram_bot/.env.example
@@ -1,0 +1,22 @@
+# ── Telegram ChatOps bot ──────────────────────────────────────────────────────
+# Copy to .env (next to where you run the bot) and fill in. NEVER commit the real .env.
+
+# Bot token from @BotFather. Rotate at least every 6 months.
+TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrSTUvwxYZ
+
+# Allowlist of chat IDs permitted to use the bot (comma-separated).
+# Get your ID from @userinfobot. EMPTY = fail-closed (bot denies everyone).
+# Group/supergroup IDs are negative, e.g. -1001234567890.
+TELEGRAM_ALLOWED_CHAT_IDS=
+
+# Optional: subset of the allowlist with admin privileges (reserved for future
+# write/trigger commands). Comma-separated.
+TELEGRAM_ADMIN_CHAT_IDS=
+
+# Where the DCN Network Tool API is reachable (same default as mcp_dcn_server.py).
+DCN_API_URL=http://localhost:5757
+
+# Per-chat rate limit (messages per 60s) and HTTP timeouts (seconds).
+TELEGRAM_RATE_LIMIT_PER_MIN=20
+TELEGRAM_REQUEST_TIMEOUT=30
+TELEGRAM_ASK_TIMEOUT=120

--- a/src/telegram_bot/README.md
+++ b/src/telegram_bot/README.md
@@ -1,0 +1,91 @@
+# DCN Telegram ChatOps Bot
+
+A bi-directional Telegram interface for the DCN Network Tool. It is a **thin,
+read-only front-end** over the existing Flask/MCP API — it adds no new network
+capability, it just gives you a fourth way to reach the tools that already exist
+(web UI, MCP/Claude, push alerts) directly from your phone.
+
+> Inspired by the "engineers shouldn't be locked into one interface" idea. Your
+> stack already had the web dashboard and the MCP/Claude interface — this fills the
+> missing *phone* interface.
+
+## Commands
+
+| Command | Backend endpoint | What it does |
+|---|---|---|
+| `/health` | `GET /api/health` | API + lab health |
+| `/sites` | `GET /api/sites` | List datacenter sites |
+| `/devices [filter]` | `GET /api/devices` | List devices (optional hostname filter) |
+| `/topo` | `GET /api/mv/topology` | Multivendor topology snapshot |
+| `/bgp [site]` | `GET /api/report/bgp` | Network-wide BGP session health |
+| `/incident <ip>` | `POST /api/incident` | Collect incident data for a device |
+| `/ask <question>` | `POST /api/mv/orchestrator` | Free-text Q&A via the Qwen3→Claude orchestrator |
+| `/help` | — | Show help |
+
+## Run it
+
+```bash
+# 1. Install deps (opt-in; not pulled in by the main DCN app)
+python -m venv .venv && source .venv/bin/activate
+pip install -r telegram_bot/requirements.txt
+
+# 2. Configure
+cp telegram_bot/.env.example telegram_bot/.env
+#    edit: TELEGRAM_BOT_TOKEN + TELEGRAM_ALLOWED_CHAT_IDS (your @userinfobot id)
+set -a && source telegram_bot/.env && set +a
+
+# 3. Run (long-polling — no inbound port / public TLS needed)
+python -m telegram_bot.bot
+```
+
+The DCN API must be reachable at `DCN_API_URL` (default `http://localhost:5757`).
+
+## Security model
+
+- **Fail-closed allowlist** on every command — an empty `TELEGRAM_ALLOWED_CHAT_IDS`
+  denies everyone. Group IDs (negative) are supported.
+- **Per-chat rate limiting** (sliding window).
+- **Audit logging** — every command and every denial is logged (chat id, user,
+  command), consistent with the GAIT/AEGIS evidence ethos.
+- **Long-polling**, not webhooks — no inbound firewall port, no public TLS cert.
+- **Read + diagnose only.** No config push from chat by design. A future
+  `/preflight` should *trigger* an AEGIS run but still require the human authorize
+  step in the web UI — never seal a change from a phone tap.
+- Keep the token in `.env` (never commit it) and **rotate** it periodically.
+
+> ⚠️ **Air-gap boundary:** Telegram relays messages through Telegram's cloud. This
+> is fine for the lab/DCN observability tier, but it must **not** carry a regulated
+> air-gapped AEGIS customer's topology/config — that would break AEGIS's "no egress
+> ever" promise. For that tier, keep it dashboard-only or use self-hosted Matrix.
+
+## Architecture (testable split)
+
+```
+config.py      immutable env-driven settings (token, allowlist, timeouts)
+auth.py        parse_chat_ids / is_authorized / is_admin / RateLimiter   (pure)
+dcn_client.py  async httpx client over the DCN API (DCNError normalisation)
+formatting.py  API JSON -> Telegram-safe text (length-capped, defensive)  (pure)
+bot.py         python-telegram-bot wiring: guard + handlers + audit + errors
+```
+
+`auth`, `config`, `dcn_client`, and `formatting` carry no Telegram dependency, so
+the logic is unit-tested without it. See `../tests/test_tg_*.py` (65 tests, 88%
+coverage; auth/config 100%).
+
+## Tests
+
+```bash
+pip install pytest pytest-cov httpx
+pytest tests/test_tg_*.py --cov=telegram_bot --cov-report=term-missing
+```
+
+## References (best practices applied)
+
+- python-telegram-bot docs/architecture — async `Application`, modular handlers.
+- "Building Robust Telegram Bots" — async, edit-in-place UX, env config.
+- Telegram bot access control (Advanced Web Machinery) & Home Assistant ACL —
+  allowlisting chat IDs.
+- BAZU "How to secure a Telegram bot" — token hygiene, rotation, rate limiting.
+- TechTarget "ChatOps to automate network tasks" — start read-only, fixed commands.
+- Ported patterns: nautobot-chatops (dispatcher), telegram-ha-monitor (RBAC),
+  telegram-librenms-bot (self-monitoring).

--- a/src/telegram_bot/__init__.py
+++ b/src/telegram_bot/__init__.py
@@ -1,0 +1,17 @@
+"""
+telegram_bot — bi-directional Telegram ChatOps front-end for the DCN Network Tool.
+
+A thin, read-only interface over the existing DCN Flask API (the same endpoints the
+MCP server wraps). It does NOT add new network capability — it gives the operator a
+fourth way to reach the tools that already exist (web UI, MCP/Claude, alerts → phone).
+
+Design split (keeps the logic testable without Telegram installed):
+  config       — immutable settings loaded from the environment
+  auth         — allowlist + RBAC + rate limiting (fail-closed)
+  dcn_client   — async httpx client for the DCN API
+  formatting   — API JSON -> Telegram-safe message text
+  bot          — python-telegram-bot wiring (handlers, audit log, error handler)
+"""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/telegram_bot/auth.py
+++ b/src/telegram_bot/auth.py
@@ -1,0 +1,83 @@
+"""
+auth.py — authorization and rate limiting for the Telegram ChatOps bot.
+
+Pure, dependency-free logic so it can be unit-tested in isolation and reasoned
+about for security. Two principles:
+
+  * Fail closed — an empty allowlist authorizes nobody. A misconfigured bot is a
+    silent bot, never an open one.
+  * Per-chat rate limiting with an injectable clock so the sliding window is
+    deterministic under test.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import Callable, Deque, Dict
+
+
+def parse_chat_ids(raw: str | None) -> frozenset[int]:
+    """Parse a comma/space separated list of Telegram chat IDs from an env var.
+
+    Group/supergroup IDs are negative, so signs are preserved. Blank entries are
+    ignored; a genuinely non-numeric token raises ValueError so a misconfigured
+    allowlist fails loudly at startup rather than silently dropping an admin.
+    """
+    if not raw:
+        return frozenset()
+    ids: set[int] = set()
+    for token in raw.replace(" ", ",").split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            ids.add(int(token))
+        except ValueError as exc:  # noqa: PERF203 — clarity over micro-perf
+            raise ValueError(f"invalid Telegram chat id: {token!r}") from exc
+    return frozenset(ids)
+
+
+def is_authorized(chat_id: int | None, allowed: frozenset[int]) -> bool:
+    """True only if chat_id is explicitly allowlisted. Empty allowlist => deny all."""
+    if chat_id is None:
+        return False
+    return chat_id in allowed
+
+
+def is_admin(chat_id: int | None, admins: frozenset[int]) -> bool:
+    """True only if chat_id is in the admin set."""
+    if chat_id is None:
+        return False
+    return chat_id in admins
+
+
+class RateLimiter:
+    """Sliding-window per-chat rate limiter.
+
+    Allows at most ``max_per_window`` calls per ``window_seconds`` for each chat.
+    The clock is injectable to keep tests deterministic (no real sleeping).
+    """
+
+    def __init__(
+        self,
+        max_per_window: int,
+        window_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._max = max_per_window
+        self._window = window_seconds
+        self._clock = clock
+        self._hits: Dict[int, Deque[float]] = defaultdict(deque)
+
+    def allow(self, chat_id: int) -> bool:
+        """Record an attempt; return True if it is within the limit, else False."""
+        now = self._clock()
+        bucket = self._hits[chat_id]
+        cutoff = now - self._window
+        while bucket and bucket[0] <= cutoff:
+            bucket.popleft()
+        if len(bucket) >= self._max:
+            return False
+        bucket.append(now)
+        return True

--- a/src/telegram_bot/auth.py
+++ b/src/telegram_bot/auth.py
@@ -52,6 +52,26 @@ def is_admin(chat_id: int | None, admins: frozenset[int]) -> bool:
     return chat_id in admins
 
 
+def summarize_command(text: str, max_args_len: int = 24) -> str:
+    """Reduce a raw message to 'command + truncated args' for audit logging.
+
+    Keeps the command verb (e.g. ``/ask``) for auditability but truncates the
+    arguments, so a potentially sensitive ``/ask`` prompt is never recorded
+    verbatim in the logs.
+    """
+    text = (text or "").strip()
+    if not text:
+        return "(empty)"
+    parts = text.split(maxsplit=1)
+    command = parts[0]
+    if len(parts) == 1:
+        return command
+    args = parts[1]
+    if len(args) > max_args_len:
+        args = args[:max_args_len] + "…"
+    return f"{command} {args}"
+
+
 class RateLimiter:
     """Sliding-window per-chat rate limiter.
 

--- a/src/telegram_bot/auth.py
+++ b/src/telegram_bot/auth.py
@@ -71,7 +71,12 @@ class RateLimiter:
         self._hits: Dict[int, Deque[float]] = defaultdict(deque)
 
     def allow(self, chat_id: int) -> bool:
-        """Record an attempt; return True if it is within the limit, else False."""
+        """Record an attempt; return True if it is within the limit, else False.
+
+        A non-positive ``max_per_window`` disables rate limiting (so a mistyped
+        ``TELEGRAM_RATE_LIMIT_PER_MIN=0`` does not silently block every chat)."""
+        if self._max <= 0:
+            return True
         now = self._clock()
         bucket = self._hits[chat_id]
         cutoff = now - self._window

--- a/src/telegram_bot/bot.py
+++ b/src/telegram_bot/bot.py
@@ -1,0 +1,248 @@
+"""
+bot.py — python-telegram-bot (v20+/async) wiring for the DCN ChatOps bot.
+
+Thin glue: every handler is wrapped by an auth guard (allowlist + rate limit +
+audit log), then calls the async DCNClient and a pure formatter. Long-running
+work (notably /ask, which routes through the Qwen3->Claude orchestrator) is run
+with concurrent updates enabled and a "working…" placeholder that is edited in
+place, so one slow request never blocks the others.
+
+Security posture (see references/best-practices in the package README):
+  * fail-closed allowlist on EVERY command,
+  * per-chat rate limiting,
+  * every command (and every denial) is audit-logged,
+  * long-polling — no inbound port or public TLS endpoint required,
+  * read-only + diagnose only; no config-push from chat.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Awaitable, Callable
+
+import httpx
+from telegram import BotCommand, Update
+from telegram.constants import ParseMode
+from telegram.error import BadRequest
+from telegram.ext import Application, ApplicationBuilder, CommandHandler, ContextTypes
+
+from .auth import RateLimiter, is_authorized
+from .config import BotConfig
+from .dcn_client import DCNClient, DCNError
+from . import formatting as fmt
+
+log = logging.getLogger("dcn.telegram")
+
+Handler = Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[None]]
+
+_HELP = (
+    "🛰️ *DCN ChatOps*\n"
+    "Read-only access to the DCN Network Tool.\n\n"
+    "/health — API + lab health\n"
+    "/sites — list datacenter sites\n"
+    "/devices [filter] — list devices (optional hostname filter)\n"
+    "/topo — multivendor topology snapshot\n"
+    "/bgp [site] — network-wide BGP session health\n"
+    "/incident <ip> — collect incident data for a device\n"
+    "/ask <question> — ask the AI orchestrator (Qwen3→Claude)\n"
+)
+
+_COMMANDS = [
+    BotCommand("health", "API + lab health"),
+    BotCommand("sites", "List datacenter sites"),
+    BotCommand("devices", "List devices [filter]"),
+    BotCommand("topo", "Topology snapshot"),
+    BotCommand("bgp", "BGP session health [site]"),
+    BotCommand("incident", "Incident data <ip>"),
+    BotCommand("ask", "Ask the AI orchestrator <question>"),
+    BotCommand("help", "Show help"),
+]
+
+
+class ChatOpsBot:
+    def __init__(self, config: BotConfig) -> None:
+        self.config = config
+        self.limiter = RateLimiter(config.rate_limit_per_min, 60.0)
+        self._dcn: DCNClient | None = None
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def build(self) -> Application:
+        app = (
+            ApplicationBuilder()
+            .token(self.config.token)
+            .concurrent_updates(True)
+            .post_init(self._on_start)
+            .post_shutdown(self._on_stop)
+            .build()
+        )
+        app.add_handler(CommandHandler("start", self._guard(self.cmd_help)))
+        app.add_handler(CommandHandler("help", self._guard(self.cmd_help)))
+        app.add_handler(CommandHandler("health", self._guard(self.cmd_health)))
+        app.add_handler(CommandHandler("sites", self._guard(self.cmd_sites)))
+        app.add_handler(CommandHandler("devices", self._guard(self.cmd_devices)))
+        app.add_handler(CommandHandler("topo", self._guard(self.cmd_topo)))
+        app.add_handler(CommandHandler("bgp", self._guard(self.cmd_bgp)))
+        app.add_handler(CommandHandler("incident", self._guard(self.cmd_incident)))
+        app.add_handler(CommandHandler("ask", self._guard(self.cmd_ask)))
+        app.add_error_handler(self._on_error)
+        return app
+
+    async def _on_start(self, app: Application) -> None:
+        client = httpx.AsyncClient()
+        app.bot_data["http"] = client
+        self._dcn = DCNClient(
+            base_url=self.config.dcn_api_url,
+            client=client,
+            timeout=self.config.request_timeout,
+            ask_timeout=self.config.ask_timeout,
+        )
+        await app.bot.set_my_commands(_COMMANDS)
+        log.info("ChatOps bot online — DCN API %s", self.config.dcn_api_url)
+
+    async def _on_stop(self, app: Application) -> None:
+        client = app.bot_data.get("http")
+        if client is not None:
+            await client.aclose()
+
+    # ── auth guard ───────────────────────────────────────────────────────────
+    def _guard(self, handler: Handler) -> Handler:
+        @functools.wraps(handler)
+        async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+            chat = update.effective_chat
+            chat_id = chat.id if chat else None
+            user = update.effective_user
+            who = (user.username or user.full_name) if user else "?"
+            msg = update.effective_message
+            text = (msg.text if msg else "") or ""
+
+            if not is_authorized(chat_id, self.config.allowed_chat_ids):
+                log.warning("DENIED chat_id=%s user=%s cmd=%r", chat_id, who, text)
+                if msg:
+                    await msg.reply_text("⛔ Not authorized for this bot.")
+                return
+            if not self.limiter.allow(chat_id):
+                log.warning("RATELIMIT chat_id=%s user=%s", chat_id, who)
+                if msg:
+                    await msg.reply_text("⏳ Rate limit reached — try again shortly.")
+                return
+            log.info("CMD chat_id=%s user=%s cmd=%r", chat_id, who, text)
+            await handler(update, context)
+
+        return wrapper
+
+    # ── reply helpers ──────────────────────────────────────────────────────────
+    @staticmethod
+    async def _send(update: Update, text: str) -> None:
+        """Send Markdown, falling back to plain text if Telegram rejects entities."""
+        msg = update.effective_message
+        if msg is None:
+            return
+        try:
+            await msg.reply_text(text, parse_mode=ParseMode.MARKDOWN)
+        except BadRequest:
+            await msg.reply_text(text)
+
+    # ── command handlers ───────────────────────────────────────────────────────
+    async def cmd_help(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        await self._send(update, _HELP)
+
+    async def cmd_health(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        await self._run(update, lambda: self._dcn.health(), fmt.format_health)
+
+    async def cmd_sites(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        await self._run(update, lambda: self._dcn.list_sites(), fmt.format_sites)
+
+    async def cmd_devices(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        search = " ".join(context.args) if context.args else ""
+        await self._run(
+            update, lambda: self._dcn.list_devices(search=search), fmt.format_devices
+        )
+
+    async def cmd_topo(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        await self._run(
+            update,
+            lambda: self._dcn.topology(),
+            lambda d: fmt.format_report("Topology", d),
+        )
+
+    async def cmd_bgp(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        site = context.args[0] if context.args else ""
+        await self._run(
+            update,
+            lambda: self._dcn.report_bgp(site=site),
+            lambda d: fmt.format_report("BGP sessions", d),
+        )
+
+    async def cmd_incident(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not context.args:
+            await self._send(update, "Usage: `/incident <device-ip>`")
+            return
+        ip = context.args[0]
+        await self._run(
+            update,
+            lambda: self._dcn.incident(ip),
+            lambda d: fmt.format_report(f"Incident {ip}", d),
+        )
+
+    async def cmd_ask(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        prompt = " ".join(context.args) if context.args else ""
+        if not prompt.strip():
+            await self._send(update, "Usage: `/ask <your question>`")
+            return
+        msg = update.effective_message
+        placeholder = await msg.reply_text("🤖 Thinking… (Qwen3→Claude)")
+        try:
+            data = await self._dcn.ask(prompt)
+            text = fmt.format_ask(data)
+        except DCNError as exc:
+            text = fmt.format_error(str(exc))
+        try:
+            await placeholder.edit_text(text, parse_mode=ParseMode.MARKDOWN)
+        except BadRequest:
+            await placeholder.edit_text(text)
+
+    async def _run(
+        self,
+        update: Update,
+        call: Callable[[], Awaitable],
+        formatter: Callable[[object], str],
+    ) -> None:
+        """Execute a DCN call, format the result, reply — turning DCNError into a
+        friendly message rather than an unhandled exception."""
+        try:
+            data = await call()
+        except DCNError as exc:
+            await self._send(update, fmt.format_error(str(exc)))
+            return
+        await self._send(update, formatter(data))
+
+    # ── error handler ──────────────────────────────────────────────────────────
+    async def _on_error(self, update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+        log.exception("Unhandled error", exc_info=context.error)
+        if isinstance(update, Update) and update.effective_message:
+            try:
+                await update.effective_message.reply_text("⚠️ Internal error — logged.")
+            except Exception:  # noqa: BLE001 — never let the error handler raise
+                pass
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    config = BotConfig.from_env()
+    if not config.allowed_chat_ids:
+        log.warning(
+            "TELEGRAM_ALLOWED_CHAT_IDS is empty — bot will DENY all chats "
+            "(fail-closed). Set it to your @userinfobot chat id to enable."
+        )
+    bot = ChatOpsBot(config)
+    app = bot.build()
+    log.info("Starting DCN ChatOps bot (long-polling)")
+    app.run_polling(allowed_updates=Update.ALL_TYPES)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/telegram_bot/bot.py
+++ b/src/telegram_bot/bot.py
@@ -27,7 +27,7 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest
 from telegram.ext import Application, ApplicationBuilder, CommandHandler, ContextTypes
 
-from .auth import RateLimiter, is_authorized
+from .auth import RateLimiter, is_authorized, summarize_command
 from .config import BotConfig
 from .dcn_client import DCNClient, DCNError
 from . import formatting as fmt
@@ -96,6 +96,7 @@ class ChatOpsBot:
             client=client,
             timeout=self.config.request_timeout,
             ask_timeout=self.config.ask_timeout,
+            report_timeout=self.config.report_timeout,
         )
         await app.bot.set_my_commands(_COMMANDS)
         log.info("ChatOps bot online — DCN API %s", self.config.dcn_api_url)
@@ -115,9 +116,10 @@ class ChatOpsBot:
             who = (user.username or user.full_name) if user else "?"
             msg = update.effective_message
             text = (msg.text if msg else "") or ""
+            audit = summarize_command(text)  # command kept, args truncated
 
             if not is_authorized(chat_id, self.config.allowed_chat_ids):
-                log.warning("DENIED chat_id=%s user=%s cmd=%r", chat_id, who, text)
+                log.warning("DENIED chat_id=%s user=%s cmd=%r", chat_id, who, audit)
                 if msg:
                     await msg.reply_text("⛔ Not authorized for this bot.")
                 return
@@ -126,7 +128,7 @@ class ChatOpsBot:
                 if msg:
                     await msg.reply_text("⏳ Rate limit reached — try again shortly.")
                 return
-            log.info("CMD chat_id=%s user=%s cmd=%r", chat_id, who, text)
+            log.info("CMD chat_id=%s user=%s cmd=%r", chat_id, who, audit)
             await handler(update, context)
 
         return wrapper

--- a/src/telegram_bot/com.gesh.dcn-telegram-bot.plist.template
+++ b/src/telegram_bot/com.gesh.dcn-telegram-bot.plist.template
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd template for the DCN Telegram ChatOps bot.
+  Install with telegram_bot/install_launchd.sh (substitutes __SRC_DIR__ / __LOG_DIR__
+  and bootstraps the agent). Do not load this template directly.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.gesh.dcn-telegram-bot</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__SRC_DIR__/telegram_bot/run.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__SRC_DIR__</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart only on a crash (non-zero exit). A clean exit 0 (no token yet)
+         leaves the service dormant instead of crash-looping. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/dcn-telegram-bot.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/dcn-telegram-bot.err.log</string>
+</dict>
+</plist>

--- a/src/telegram_bot/config.py
+++ b/src/telegram_bot/config.py
@@ -25,6 +25,7 @@ class BotConfig:
     rate_limit_per_min: int = 20
     request_timeout: float = 30.0
     ask_timeout: float = 120.0
+    report_timeout: float = 300.0
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> "BotConfig":
@@ -42,4 +43,5 @@ class BotConfig:
             rate_limit_per_min=int(env.get("TELEGRAM_RATE_LIMIT_PER_MIN", "20")),
             request_timeout=float(env.get("TELEGRAM_REQUEST_TIMEOUT", "30")),
             ask_timeout=float(env.get("TELEGRAM_ASK_TIMEOUT", "120")),
+            report_timeout=float(env.get("TELEGRAM_REPORT_TIMEOUT", "300")),
         )

--- a/src/telegram_bot/config.py
+++ b/src/telegram_bot/config.py
@@ -1,0 +1,45 @@
+"""
+config.py — immutable, env-driven configuration for the ChatOps bot.
+
+Loaded once at startup. Missing token is fatal; the chat-ID allowlist is parsed
+here so a bad value fails loudly before the bot ever goes online.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .auth import parse_chat_ids
+
+DEFAULT_DCN_API_URL = "http://localhost:5757"
+
+
+@dataclass(frozen=True)
+class BotConfig:
+    token: str
+    allowed_chat_ids: frozenset[int]
+    admin_chat_ids: frozenset[int]
+    dcn_api_url: str = DEFAULT_DCN_API_URL
+    rate_limit_per_min: int = 20
+    request_timeout: float = 30.0
+    ask_timeout: float = 120.0
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "BotConfig":
+        env = env if env is not None else os.environ
+        token = (env.get("TELEGRAM_BOT_TOKEN") or "").strip()
+        if not token:
+            raise ValueError(
+                "TELEGRAM_BOT_TOKEN is required (create a bot via @BotFather)"
+            )
+        return cls(
+            token=token,
+            allowed_chat_ids=parse_chat_ids(env.get("TELEGRAM_ALLOWED_CHAT_IDS")),
+            admin_chat_ids=parse_chat_ids(env.get("TELEGRAM_ADMIN_CHAT_IDS")),
+            dcn_api_url=(env.get("DCN_API_URL") or DEFAULT_DCN_API_URL).rstrip("/"),
+            rate_limit_per_min=int(env.get("TELEGRAM_RATE_LIMIT_PER_MIN", "20")),
+            request_timeout=float(env.get("TELEGRAM_REQUEST_TIMEOUT", "30")),
+            ask_timeout=float(env.get("TELEGRAM_ASK_TIMEOUT", "120")),
+        )

--- a/src/telegram_bot/dcn_client.py
+++ b/src/telegram_bot/dcn_client.py
@@ -33,6 +33,7 @@ class DCNClient:
     client: httpx.AsyncClient
     timeout: float = 30.0
     ask_timeout: float = 120.0
+    report_timeout: float = 300.0
 
     async def _get(self, path: str, params: dict | None = None,
                    timeout: float | None = None) -> Any:
@@ -80,11 +81,13 @@ class DCNClient:
         return await self._get("/api/mv/topology")
 
     async def report_bgp(self, site: str = "") -> Any:
-        return await self._get("/api/report/bgp", {"site": site}, timeout=300.0)
+        return await self._get(
+            "/api/report/bgp", {"site": site}, timeout=self.report_timeout
+        )
 
     async def incident(self, ip: str, dtype: str = "junos") -> Any:
         return await self._post(
-            "/api/incident", {"ip": ip, "dtype": dtype}, timeout=300.0
+            "/api/incident", {"ip": ip, "dtype": dtype}, timeout=self.report_timeout
         )
 
     # ── LLM Q&A (Phase 2) ────────────────────────────────────────────────────

--- a/src/telegram_bot/dcn_client.py
+++ b/src/telegram_bot/dcn_client.py
@@ -1,0 +1,96 @@
+"""
+dcn_client.py — async HTTP client for the DCN Network Tool API.
+
+The only component that touches the network. It mirrors the endpoint map already
+used by ``mcp_dcn_server.py`` (same base URL convention, ``DCN_API_URL``), but is
+async (httpx) to fit python-telegram-bot v20+'s event loop.
+
+All transport/HTTP failures are normalised to ``DCNError`` so handlers can show a
+friendly message instead of leaking a stack trace into a chat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+class DCNError(Exception):
+    """Raised when the DCN API is unreachable or returns a non-success status."""
+
+
+@dataclass(frozen=True)
+class DCNClient:
+    """Async client over the DCN Flask API.
+
+    ``client`` is injected so production code shares one pooled AsyncClient and
+    tests can pass an httpx.MockTransport-backed client (no live server).
+    """
+
+    base_url: str
+    client: httpx.AsyncClient
+    timeout: float = 30.0
+    ask_timeout: float = 120.0
+
+    async def _get(self, path: str, params: dict | None = None,
+                   timeout: float | None = None) -> Any:
+        clean = {k: v for k, v in (params or {}).items() if v not in (None, "")}
+        try:
+            resp = await self.client.get(
+                f"{self.base_url}{path}", params=clean,
+                timeout=timeout or self.timeout,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as exc:
+            raise DCNError(f"{path} -> HTTP {exc.response.status_code}") from exc
+        except httpx.HTTPError as exc:
+            raise DCNError(f"{path} -> {exc}") from exc
+
+    async def _post(self, path: str, body: dict,
+                    timeout: float | None = None) -> Any:
+        try:
+            resp = await self.client.post(
+                f"{self.base_url}{path}", json=body,
+                timeout=timeout or self.timeout,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as exc:
+            raise DCNError(f"{path} -> HTTP {exc.response.status_code}") from exc
+        except httpx.HTTPError as exc:
+            raise DCNError(f"{path} -> {exc}") from exc
+
+    # ── Read-only endpoints (Phase 1) ────────────────────────────────────────
+    async def health(self) -> Any:
+        return await self._get("/api/health")
+
+    async def list_sites(self) -> Any:
+        return await self._get("/api/sites")
+
+    async def list_devices(self, site: str = "", role: str = "",
+                           search: str = "") -> Any:
+        return await self._get(
+            "/api/devices", {"site": site, "role": role, "search": search}
+        )
+
+    async def topology(self) -> Any:
+        return await self._get("/api/mv/topology")
+
+    async def report_bgp(self, site: str = "") -> Any:
+        return await self._get("/api/report/bgp", {"site": site}, timeout=300.0)
+
+    async def incident(self, ip: str, dtype: str = "junos") -> Any:
+        return await self._post(
+            "/api/incident", {"ip": ip, "dtype": dtype}, timeout=300.0
+        )
+
+    # ── LLM Q&A (Phase 2) ────────────────────────────────────────────────────
+    async def ask(self, prompt: str) -> Any:
+        """Route a free-text question through the Pydantic-AI orchestrator
+        (which uses the local Qwen3 -> Claude fallback chain server-side)."""
+        return await self._post(
+            "/api/mv/orchestrator", {"prompt": prompt}, timeout=self.ask_timeout
+        )

--- a/src/telegram_bot/formatting.py
+++ b/src/telegram_bot/formatting.py
@@ -1,0 +1,133 @@
+"""
+formatting.py — render DCN API JSON into Telegram-safe message text.
+
+Pure functions only. Every renderer must stay under Telegram's 4096-char limit and
+tolerate partial/missing fields, because the upstream API shapes vary by endpoint
+and we never want a malformed payload to crash a handler.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+TELEGRAM_MAX = 4096
+
+
+def truncate(text: str, limit: int = TELEGRAM_MAX) -> str:
+    """Clip text to ``limit`` chars, appending an ellipsis when clipped."""
+    if len(text) <= limit:
+        return text
+    if limit <= 1:
+        return text[:limit]
+    return text[: limit - 1] + "…"
+
+
+def format_error(message: str) -> str:
+    return f"⚠️ {message}"
+
+
+def _is_error(data: Any) -> str | None:
+    if isinstance(data, dict) and data.get("error"):
+        return str(data["error"])
+    return None
+
+
+def format_health(data: dict) -> str:
+    err = _is_error(data)
+    if err:
+        return format_error(f"DCN API error: {err}")
+    status = str(data.get("status", "unknown"))
+    icon = "✅" if status.lower() in {"ok", "healthy", "up"} else "⚠️"
+    devices = data.get("devices_loaded", "?")
+    ts = data.get("timestamp", "")
+    lines = [f"{icon} *DCN API:* {status}", f"Devices loaded: {devices}"]
+    if ts:
+        lines.append(f"_{ts}_")
+    return truncate("\n".join(lines))
+
+
+def _as_list(data: Any, *keys: str) -> list:
+    """Coerce a payload that is either a bare list or a dict wrapping one."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def format_sites(data: Any) -> str:
+    err = _is_error(data)
+    if err:
+        return format_error(err)
+    sites = _as_list(data, "sites")
+    if not sites:
+        return "No sites found."
+    rendered = ", ".join(str(s) for s in sites)
+    return truncate(f"🗺️ *Sites ({len(sites)}):*\n{rendered}")
+
+
+def format_devices(data: Any, limit: int = 25) -> str:
+    err = _is_error(data)
+    if err:
+        return format_error(err)
+    devices = _as_list(data, "devices")
+    if not devices:
+        return "No devices found."
+    shown = devices[:limit]
+    lines = [f"🖥️ *Devices ({len(devices)}):*"]
+    for dev in shown:
+        if isinstance(dev, dict):
+            host = dev.get("hostname") or dev.get("name") or dev.get("ip") or "?"
+            site = dev.get("site", "")
+            dtype = dev.get("type") or dev.get("vendor") or ""
+            meta = " · ".join(p for p in (site, dtype) if p)
+            lines.append(f"• `{host}`" + (f" — {meta}" if meta else ""))
+        else:
+            lines.append(f"• {dev}")
+    hidden = len(devices) - len(shown)
+    if hidden > 0:
+        lines.append(f"…and {hidden} more")
+    return truncate("\n".join(lines))
+
+
+def format_ask(data: Any) -> str:
+    """Render the orchestrator (/ask) response, preferring its rendered narrative."""
+    err = _is_error(data)
+    if err:
+        return format_error(err)
+    if isinstance(data, dict):
+        for key in ("rendered", "output", "answer", "result", "summary"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                agent = data.get("agent")
+                header = f"🤖 *{agent}*\n" if agent else ""
+                return truncate(header + value.strip())
+        return truncate("🤖\n" + json.dumps(data, indent=2, default=str))
+    return truncate(str(data))
+
+
+def format_report(title: str, data: Any) -> str:
+    """Generic renderer for endpoints whose schema we don't pin (BGP, topology…).
+
+    Always readable: errors surface plainly, dicts render as key/value lines,
+    lists render as a count plus a pretty JSON preview, all length-capped.
+    """
+    err = _is_error(data)
+    if err:
+        return format_error(f"{title}: {err}")
+    header = f"📊 *{title}*"
+    if isinstance(data, dict):
+        lines = [header]
+        for key, value in data.items():
+            if isinstance(value, (dict, list)):
+                value = json.dumps(value, default=str)
+            lines.append(f"• {key}: {value}")
+        return truncate("\n".join(lines))
+    if isinstance(data, list):
+        preview = json.dumps(data, indent=2, default=str)
+        return truncate(f"{header} ({len(data)} items)\n```\n{preview}\n```")
+    return truncate(f"{header}\n{data}")

--- a/src/telegram_bot/formatting.py
+++ b/src/telegram_bot/formatting.py
@@ -28,14 +28,16 @@ def format_error(message: str) -> str:
 
 
 def _is_error(data: Any) -> str | None:
-    if isinstance(data, dict) and data.get("error"):
+    # Key presence, not truthiness: an API that returns {"error": ""} or
+    # {"error": 0} is still reporting an error and must not be rendered as data.
+    if isinstance(data, dict) and "error" in data:
         return str(data["error"])
     return None
 
 
 def format_health(data: dict) -> str:
     err = _is_error(data)
-    if err:
+    if err is not None:
         return format_error(f"DCN API error: {err}")
     status = str(data.get("status", "unknown"))
     icon = "✅" if status.lower() in {"ok", "healthy", "up"} else "⚠️"
@@ -61,7 +63,7 @@ def _as_list(data: Any, *keys: str) -> list:
 
 def format_sites(data: Any) -> str:
     err = _is_error(data)
-    if err:
+    if err is not None:
         return format_error(err)
     sites = _as_list(data, "sites")
     if not sites:
@@ -72,7 +74,7 @@ def format_sites(data: Any) -> str:
 
 def format_devices(data: Any, limit: int = 25) -> str:
     err = _is_error(data)
-    if err:
+    if err is not None:
         return format_error(err)
     devices = _as_list(data, "devices")
     if not devices:
@@ -97,7 +99,7 @@ def format_devices(data: Any, limit: int = 25) -> str:
 def format_ask(data: Any) -> str:
     """Render the orchestrator (/ask) response, preferring its rendered narrative."""
     err = _is_error(data)
-    if err:
+    if err is not None:
         return format_error(err)
     if isinstance(data, dict):
         for key in ("rendered", "output", "answer", "result", "summary"):
@@ -117,7 +119,7 @@ def format_report(title: str, data: Any) -> str:
     lists render as a count plus a pretty JSON preview, all length-capped.
     """
     err = _is_error(data)
-    if err:
+    if err is not None:
         return format_error(f"{title}: {err}")
     header = f"📊 *{title}*"
     if isinstance(data, dict):

--- a/src/telegram_bot/install_launchd.sh
+++ b/src/telegram_bot/install_launchd.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install (or reinstall) the DCN Telegram ChatOps bot as a launchd user agent.
+#
+#   ./telegram_bot/install_launchd.sh
+#
+# Creates src/.venv (if absent) with the bot's deps, renders the plist from the
+# template, and bootstraps the agent. Idempotent — safe to re-run. Uninstall with:
+#   launchctl bootout gui/$(id -u)/com.gesh.dcn-telegram-bot
+#   rm ~/Library/LaunchAgents/com.gesh.dcn-telegram-bot.plist
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # -> .../src
+LABEL="com.gesh.dcn-telegram-bot"
+LA_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/Library/Logs"
+PLIST="$LA_DIR/$LABEL.plist"
+TEMPLATE="$SRC_DIR/telegram_bot/$LABEL.plist.template"
+UID_NUM="$(id -u)"
+
+mkdir -p "$LA_DIR" "$LOG_DIR"
+
+# 1. Ensure a venv with the bot's deps exists.
+if [ ! -x "$SRC_DIR/.venv/bin/python" ]; then
+  echo "[install] creating venv at $SRC_DIR/.venv"
+  python3 -m venv "$SRC_DIR/.venv"
+fi
+echo "[install] installing deps from telegram_bot/requirements.txt"
+"$SRC_DIR/.venv/bin/python" -m pip install -q --upgrade pip
+"$SRC_DIR/.venv/bin/python" -m pip install -q -r "$SRC_DIR/telegram_bot/requirements.txt"
+
+# 2. Render the plist from the template (absolute paths for this machine).
+sed -e "s|__SRC_DIR__|$SRC_DIR|g" -e "s|__LOG_DIR__|$LOG_DIR|g" "$TEMPLATE" > "$PLIST"
+echo "[install] wrote $PLIST"
+
+# 3. (Re)bootstrap the agent.
+launchctl bootout "gui/$UID_NUM/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$UID_NUM" "$PLIST"
+launchctl enable "gui/$UID_NUM/$LABEL"
+echo "[install] bootstrapped $LABEL"
+
+echo
+echo "Next:"
+echo "  1. edit $SRC_DIR/telegram_bot/.env  (TELEGRAM_BOT_TOKEN + TELEGRAM_ALLOWED_CHAT_IDS)"
+echo "  2. launchctl kickstart -k gui/$UID_NUM/$LABEL"
+echo "  logs: $LOG_DIR/dcn-telegram-bot.{out,err}.log"

--- a/src/telegram_bot/requirements.txt
+++ b/src/telegram_bot/requirements.txt
@@ -1,0 +1,3 @@
+# Telegram ChatOps bot — runtime dependencies (opt-in; not required by the DCN app)
+python-telegram-bot>=21.6
+httpx>=0.27

--- a/src/telegram_bot/run.sh
+++ b/src/telegram_bot/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Launch wrapper for the DCN Telegram ChatOps bot (invoked by launchd).
+#
+# Resolves the src/ dir relative to this script, loads telegram_bot/.env, and
+# execs the bot in the project venv. If no token is configured it exits cleanly
+# (0) so launchd's KeepAlive/SuccessfulExit=false does NOT crash-loop — the
+# service stays dormant until you fill in .env, then `launchctl kickstart` it.
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # -> .../src
+cd "$SRC_DIR"
+
+ENV_FILE="$SRC_DIR/telegram_bot/.env"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then
+  echo "[dcn-telegram-bot] TELEGRAM_BOT_TOKEN not set in $ENV_FILE — not starting (dormant)."
+  exit 0
+fi
+
+VENV_PY="$SRC_DIR/.venv/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+  VENV_PY="$(command -v python3)"
+fi
+
+echo "[dcn-telegram-bot] starting with $VENV_PY against ${DCN_API_URL:-http://localhost:5757}"
+exec "$VENV_PY" -m telegram_bot.bot

--- a/src/tests/test_tg_auth.py
+++ b/src/tests/test_tg_auth.py
@@ -1,0 +1,94 @@
+"""
+test_tg_auth.py — Telegram ChatOps bot: authorization + rate limiting.
+
+Security-critical pure logic (no Telegram, no network). These are the gates that
+decide who may talk to the bot and how often, so they get exhaustive coverage,
+including the fail-closed default (empty allowlist denies everyone).
+"""
+
+import pytest
+
+from telegram_bot.auth import (
+    parse_chat_ids,
+    is_authorized,
+    is_admin,
+    RateLimiter,
+)
+
+
+class TestParseChatIds:
+    def test_parses_comma_separated(self):
+        assert parse_chat_ids("123,456,789") == frozenset({123, 456, 789})
+
+    def test_handles_spaces_and_trailing_comma(self):
+        assert parse_chat_ids(" 123 , 456 , ") == frozenset({123, 456})
+
+    def test_none_returns_empty(self):
+        assert parse_chat_ids(None) == frozenset()
+
+    def test_blank_string_returns_empty(self):
+        assert parse_chat_ids("   ") == frozenset()
+
+    def test_negative_group_ids_allowed(self):
+        # Telegram group/supergroup chat IDs are negative.
+        assert parse_chat_ids("-1001234567890") == frozenset({-1001234567890})
+
+    def test_invalid_token_raises(self):
+        with pytest.raises(ValueError):
+            parse_chat_ids("123,not-an-id")
+
+
+class TestIsAuthorized:
+    def test_member_allowed(self):
+        assert is_authorized(123, frozenset({123, 456})) is True
+
+    def test_non_member_denied(self):
+        assert is_authorized(999, frozenset({123})) is False
+
+    def test_empty_allowlist_fails_closed(self):
+        # The most important security default: no allowlist => nobody is allowed.
+        assert is_authorized(123, frozenset()) is False
+
+    def test_none_chat_id_denied(self):
+        assert is_authorized(None, frozenset({123})) is False
+
+
+class TestIsAdmin:
+    def test_admin(self):
+        assert is_admin(1, frozenset({1})) is True
+
+    def test_not_admin(self):
+        assert is_admin(2, frozenset({1})) is False
+
+    def test_none_denied(self):
+        assert is_admin(None, frozenset({1})) is False
+
+
+class TestRateLimiter:
+    def test_allows_up_to_limit(self):
+        clock = [1000.0]
+        rl = RateLimiter(max_per_window=3, window_seconds=60, clock=lambda: clock[0])
+        assert [rl.allow(7) for _ in range(3)] == [True, True, True]
+
+    def test_blocks_over_limit(self):
+        clock = [1000.0]
+        rl = RateLimiter(3, 60, clock=lambda: clock[0])
+        for _ in range(3):
+            rl.allow(7)
+        assert rl.allow(7) is False
+
+    def test_window_slides(self):
+        clock = [1000.0]
+        rl = RateLimiter(2, 60, clock=lambda: clock[0])
+        rl.allow(7)
+        rl.allow(7)
+        assert rl.allow(7) is False
+        clock[0] += 61  # advance past the window
+        assert rl.allow(7) is True
+
+    def test_per_chat_isolation(self):
+        clock = [1000.0]
+        rl = RateLimiter(1, 60, clock=lambda: clock[0])
+        assert rl.allow(1) is True
+        assert rl.allow(2) is True  # different chat is unaffected
+        assert rl.allow(1) is False

--- a/src/tests/test_tg_auth.py
+++ b/src/tests/test_tg_auth.py
@@ -13,6 +13,7 @@ from telegram_bot.auth import (
     is_authorized,
     is_admin,
     RateLimiter,
+    summarize_command,
 )
 
 
@@ -109,3 +110,24 @@ class TestRateLimiterMisconfiguration:
         rl = RateLimiter(-5, 60)
         assert rl.allow(1) is True
         assert rl.allow(1) is True
+
+
+class TestSummarizeCommand:
+    """Sourcery re-review #3: audit logs keep the command but truncate args
+    so sensitive /ask prompts aren't recorded verbatim."""
+
+    def test_command_only(self):
+        assert summarize_command("/health") == "/health"
+
+    def test_short_args_kept(self):
+        assert summarize_command("/bgp DE-FRA") == "/bgp DE-FRA"
+
+    def test_long_args_truncated(self):
+        out = summarize_command("/ask " + "x" * 100, max_args_len=10)
+        assert out.startswith("/ask ")
+        assert out.endswith("…")
+        assert len(out) < 30
+
+    def test_empty_text(self):
+        assert summarize_command("") == "(empty)"
+        assert summarize_command("   ") == "(empty)"

--- a/src/tests/test_tg_auth.py
+++ b/src/tests/test_tg_auth.py
@@ -92,3 +92,20 @@ class TestRateLimiter:
         assert rl.allow(1) is True
         assert rl.allow(2) is True  # different chat is unaffected
         assert rl.allow(1) is False
+
+
+class TestRateLimiterMisconfiguration:
+    """Sourcery #2: a non-positive limit must not silently block everyone.
+
+    Treat max_per_window <= 0 as 'no rate limit' (e.g. a mistyped
+    TELEGRAM_RATE_LIMIT_PER_MIN=0 should not brick the bot)."""
+
+    def test_zero_means_unlimited(self):
+        clock = [1000.0]
+        rl = RateLimiter(0, 60, clock=lambda: clock[0])
+        assert all(rl.allow(1) for _ in range(50))
+
+    def test_negative_means_unlimited(self):
+        rl = RateLimiter(-5, 60)
+        assert rl.allow(1) is True
+        assert rl.allow(1) is True

--- a/src/tests/test_tg_bot.py
+++ b/src/tests/test_tg_bot.py
@@ -1,0 +1,243 @@
+"""
+test_tg_bot.py — python-telegram-bot wiring layer.
+
+Covers the two things in bot.py worth asserting without a live Telegram:
+  1. every expected command is registered on the Application;
+  2. the auth guard denies non-allowlisted chats, allows allowlisted ones, and
+     enforces the per-chat rate limit — exercised with lightweight fakes so we
+     don't need real telegram.Update objects.
+"""
+
+import asyncio
+
+from telegram.error import BadRequest
+
+from telegram_bot.bot import ChatOpsBot
+from telegram_bot.config import BotConfig
+from telegram_bot.dcn_client import DCNError
+
+
+# ── Lightweight fakes for the guard tests ────────────────────────────────────
+class FakeMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies: list = []
+        self.child: "FakeMessage | None" = None
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.child = FakeMessage()
+        return self.child
+
+    async def edit_text(self, text, **kwargs):
+        self.replies.append(("edit", text))
+        return self
+
+
+class FakeChat:
+    def __init__(self, chat_id):
+        self.id = chat_id
+
+
+class FakeUser:
+    username = "tester"
+    full_name = "Test User"
+
+
+class FakeUpdate:
+    def __init__(self, chat_id, text=""):
+        self.effective_chat = FakeChat(chat_id)
+        self.effective_user = FakeUser()
+        self.effective_message = FakeMessage(text)
+
+
+def _bot(**env):
+    base = {"TELEGRAM_BOT_TOKEN": "123:abc"}
+    base.update(env)
+    return ChatOpsBot(BotConfig.from_env(base))
+
+
+class TestHandlerRegistration:
+    def test_expected_commands_registered(self):
+        app = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1").build()
+        names: set[str] = set()
+        for group in app.handlers.values():
+            for handler in group:
+                commands = getattr(handler, "commands", None)
+                if commands:
+                    names |= set(commands)
+        expected = {"start", "help", "health", "devices", "sites",
+                    "topo", "bgp", "incident", "ask"}
+        assert expected <= names
+
+
+class TestAuthGuard:
+    def test_denies_unauthorized_chat(self):
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
+        called: list = []
+
+        async def inner(update, context):
+            called.append(True)
+
+        update = FakeUpdate(999, "/health")
+        asyncio.run(bot._guard(inner)(update, None))
+        assert called == []  # handler never ran
+        assert update.effective_message.replies  # a denial was sent
+
+    def test_allows_authorized_chat(self):
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
+        called: list = []
+
+        async def inner(update, context):
+            called.append(True)
+
+        asyncio.run(bot._guard(inner)(FakeUpdate(1, "/health"), None))
+        assert called == [True]
+
+    def test_enforces_rate_limit(self):
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1", TELEGRAM_RATE_LIMIT_PER_MIN="1")
+        calls: list = []
+
+        async def inner(update, context):
+            calls.append(True)
+
+        guarded = bot._guard(inner)
+        asyncio.run(guarded(FakeUpdate(1, "/health"), None))  # allowed
+        asyncio.run(guarded(FakeUpdate(1, "/health"), None))  # blocked
+        assert calls == [True]  # only the first ran
+
+
+# ── Fakes for exercising command handlers without a live DCN API ─────────────
+class FakeContext:
+    def __init__(self, args=None):
+        self.args = args or []
+
+
+class FakeDCN:
+    def __init__(self, **canned):
+        self._canned = canned
+        self.calls: list = []
+
+    async def health(self):
+        self.calls.append("health")
+        return self._canned.get("health", {"status": "ok", "devices_loaded": 3})
+
+    async def list_sites(self):
+        self.calls.append("sites")
+        return self._canned.get("sites", ["DE-FRA"])
+
+    async def list_devices(self, search=""):
+        self.calls.append(("devices", search))
+        return self._canned.get("devices", [{"hostname": "de-fra-core-01"}])
+
+    async def topology(self):
+        self.calls.append("topo")
+        return self._canned.get("topo", {"nodes": 2})
+
+    async def report_bgp(self, site=""):
+        self.calls.append(("bgp", site))
+        return self._canned.get("bgp", {"down_sessions": 0})
+
+    async def incident(self, ip, dtype="junos"):
+        self.calls.append(("incident", ip))
+        return self._canned.get("incident", {"ok": True})
+
+    async def ask(self, prompt):
+        self.calls.append(("ask", prompt))
+        return self._canned.get("ask", {"rendered": "all good", "agent": "IncidentAgent"})
+
+
+class FakeErrorDCN(FakeDCN):
+    async def health(self):
+        raise DCNError("api down")
+
+
+class FlakyMessage(FakeMessage):
+    """Rejects the first Markdown send (BadRequest), accepts the plain retry."""
+
+    async def reply_text(self, text, **kwargs):
+        if "parse_mode" in kwargs:
+            raise BadRequest("can't parse entities")
+        self.replies.append(text)
+        return FakeMessage()
+
+
+class TestCommandHandlers:
+    def _ready_bot(self, dcn=None, **env):
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1", **env)
+        bot._dcn = dcn or FakeDCN()
+        return bot
+
+    def test_health_replies_status(self):
+        bot = self._ready_bot()
+        upd = FakeUpdate(1, "/health")
+        asyncio.run(bot.cmd_health(upd, FakeContext()))
+        assert any("ok" in str(r).lower() for r in upd.effective_message.replies)
+
+    def test_sites_lists(self):
+        bot = self._ready_bot()
+        upd = FakeUpdate(1, "/sites")
+        asyncio.run(bot.cmd_sites(upd, FakeContext()))
+        assert any("DE-FRA" in str(r) for r in upd.effective_message.replies)
+
+    def test_devices_passes_search_filter(self):
+        dcn = FakeDCN()
+        bot = self._ready_bot(dcn)
+        upd = FakeUpdate(1, "/devices core")
+        asyncio.run(bot.cmd_devices(upd, FakeContext(["core"])))
+        assert ("devices", "core") in dcn.calls
+
+    def test_topo_renders(self):
+        bot = self._ready_bot()
+        upd = FakeUpdate(1, "/topo")
+        asyncio.run(bot.cmd_topo(upd, FakeContext()))
+        assert any("Topology" in str(r) for r in upd.effective_message.replies)
+
+    def test_bgp_passes_site(self):
+        dcn = FakeDCN()
+        bot = self._ready_bot(dcn)
+        upd = FakeUpdate(1, "/bgp DE-FRA")
+        asyncio.run(bot.cmd_bgp(upd, FakeContext(["DE-FRA"])))
+        assert ("bgp", "DE-FRA") in dcn.calls
+
+    def test_incident_requires_ip(self):
+        bot = self._ready_bot()
+        upd = FakeUpdate(1, "/incident")
+        asyncio.run(bot.cmd_incident(upd, FakeContext([])))
+        assert any("usage" in str(r).lower() for r in upd.effective_message.replies)
+
+    def test_incident_with_ip_calls_client(self):
+        dcn = FakeDCN()
+        bot = self._ready_bot(dcn)
+        upd = FakeUpdate(1, "/incident 10.0.0.1")
+        asyncio.run(bot.cmd_incident(upd, FakeContext(["10.0.0.1"])))
+        assert ("incident", "10.0.0.1") in dcn.calls
+
+    def test_ask_requires_prompt(self):
+        bot = self._ready_bot()
+        upd = FakeUpdate(1, "/ask")
+        asyncio.run(bot.cmd_ask(upd, FakeContext([])))
+        assert any("usage" in str(r).lower() for r in upd.effective_message.replies)
+
+    def test_ask_edits_placeholder_with_answer(self):
+        bot = self._ready_bot()
+        upd = FakeUpdate(1, "/ask why is bgp down")
+        asyncio.run(bot.cmd_ask(upd, FakeContext(["why", "is", "bgp", "down"])))
+        placeholder = upd.effective_message.child
+        assert placeholder is not None
+        assert any("all good" in str(e) for e in placeholder.replies)
+
+    def test_health_handles_dcn_error_gracefully(self):
+        bot = self._ready_bot(FakeErrorDCN())
+        upd = FakeUpdate(1, "/health")
+        asyncio.run(bot.cmd_health(upd, FakeContext()))
+        assert any("api down" in str(r) for r in upd.effective_message.replies)
+
+
+class TestSendFallback:
+    def test_falls_back_to_plain_text_on_bad_request(self):
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
+        upd = FakeUpdate(1, "/health")
+        upd.effective_message = FlakyMessage()
+        asyncio.run(bot._send(upd, "*markdown*"))
+        assert "*markdown*" in upd.effective_message.replies

--- a/src/tests/test_tg_bot.py
+++ b/src/tests/test_tg_bot.py
@@ -287,3 +287,24 @@ class TestSendFallback:
         upd.effective_message = FlakyMessage()
         asyncio.run(bot._send(upd, "*markdown*"))
         assert "*markdown*" in upd.effective_message.replies
+
+
+class TestAuditLogRedaction:
+    """Sourcery re-review #3: the audit log keeps the command but not the full
+    (possibly sensitive) /ask prompt."""
+
+    def test_ask_prompt_not_logged_verbatim(self, caplog):
+        import logging
+
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
+
+        async def inner(update, context):
+            pass
+
+        upd = FakeUpdate(1, "/ask " + "a" * 40 + "SECRETTAIL")
+        with caplog.at_level(logging.INFO):
+            asyncio.run(bot._guard(inner)(upd, None))
+
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert "/ask" in logged          # command preserved for auditability
+        assert "SECRETTAIL" not in logged  # long/sensitive tail truncated away

--- a/src/tests/test_tg_bot.py
+++ b/src/tests/test_tg_bot.py
@@ -152,6 +152,12 @@ class FakeErrorDCN(FakeDCN):
         raise DCNError("api down")
 
 
+class FakeAskErrorDCN(FakeDCN):
+    async def ask(self, prompt):
+        self.calls.append(("ask", prompt))
+        raise DCNError("orchestrator down")
+
+
 class FlakyMessage(FakeMessage):
     """Rejects the first Markdown send (BadRequest), accepts the plain retry."""
 
@@ -232,6 +238,46 @@ class TestCommandHandlers:
         upd = FakeUpdate(1, "/health")
         asyncio.run(bot.cmd_health(upd, FakeContext()))
         assert any("api down" in str(r) for r in upd.effective_message.replies)
+
+    def test_ask_handles_dcn_error_in_placeholder(self):
+        # Sourcery #3: /ask error branch edits the placeholder with the error.
+        dcn = FakeAskErrorDCN()
+        bot = self._ready_bot(dcn)
+        upd = FakeUpdate(1, "/ask boom")
+        asyncio.run(bot.cmd_ask(upd, FakeContext(["boom"])))
+        assert ("ask", "boom") in dcn.calls
+        placeholder = upd.effective_message.child
+        assert placeholder is not None
+        assert any("orchestrator down" in str(e) for e in placeholder.replies)
+
+
+class TestGuardEdgeCases:
+    """Sourcery #4: guard must handle updates missing chat / message."""
+
+    def test_none_chat_is_denied_without_crash(self):
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
+        called: list = []
+
+        async def inner(update, context):
+            called.append(True)
+
+        upd = FakeUpdate(1, "/health")
+        upd.effective_chat = None  # e.g. a channel/service update
+        asyncio.run(bot._guard(inner)(upd, None))
+        assert called == []
+        assert upd.effective_message.replies  # denial still sent
+
+    def test_none_message_does_not_crash(self):
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
+        called: list = []
+
+        async def inner(update, context):
+            called.append(True)
+
+        upd = FakeUpdate(999, "/health")  # unauthorized
+        upd.effective_message = None  # no message to reply to
+        asyncio.run(bot._guard(inner)(upd, None))  # must not raise
+        assert called == []
 
 
 class TestSendFallback:

--- a/src/tests/test_tg_client.py
+++ b/src/tests/test_tg_client.py
@@ -164,6 +164,45 @@ class TestErrorHandling:
             run(go())
 
 
+class TestReportTimeout:
+    """Sourcery re-review #2: report_bgp / incident use the configurable
+    report_timeout rather than a hard-coded value."""
+
+    def test_report_bgp_uses_report_timeout(self):
+        seen = {}
+
+        class SpyClient(DCNClient):
+            async def _get(self, path, params=None, timeout=None):
+                seen["path"] = path
+                seen["timeout"] = timeout
+                return {}
+
+        async def go():
+            async with make_client(lambda r: httpx.Response(200, json={})) as c:
+                await SpyClient(base_url="http://dcn", client=c, report_timeout=99.0).report_bgp()
+
+        run(go())
+        assert seen["path"] == "/api/report/bgp"
+        assert seen["timeout"] == 99.0
+
+    def test_incident_uses_report_timeout(self):
+        seen = {}
+
+        class SpyClient(DCNClient):
+            async def _post(self, path, body, timeout=None):
+                seen["path"] = path
+                seen["timeout"] = timeout
+                return {}
+
+        async def go():
+            async with make_client(lambda r: httpx.Response(200, json={})) as c:
+                await SpyClient(base_url="http://dcn", client=c, report_timeout=99.0).incident("10.0.0.1")
+
+        run(go())
+        assert seen["path"] == "/api/incident"
+        assert seen["timeout"] == 99.0
+
+
 class TestQueryParamCleaning:
     """Sourcery #5: empty/None filter values must be dropped from the query."""
 

--- a/src/tests/test_tg_client.py
+++ b/src/tests/test_tg_client.py
@@ -162,3 +162,22 @@ class TestErrorHandling:
 
         with pytest.raises(DCNError):
             run(go())
+
+
+class TestQueryParamCleaning:
+    """Sourcery #5: empty/None filter values must be dropped from the query."""
+
+    def test_empty_and_none_params_dropped(self):
+        seen = {}
+
+        def handler(req):
+            seen["q"] = dict(req.url.params)
+            return httpx.Response(200, json=[])
+
+        async def go():
+            async with make_client(handler) as c:
+                client = DCNClient(base_url="http://dcn", client=c)
+                return await client.list_devices(site="", role=None, search="")
+
+        run(go())
+        assert seen["q"] == {}  # nothing sent when all filters are empty

--- a/src/tests/test_tg_client.py
+++ b/src/tests/test_tg_client.py
@@ -1,0 +1,164 @@
+"""
+test_tg_client.py — Telegram ChatOps bot: async DCN API client.
+
+The client is the only component that touches the network. Tests use httpx's
+built-in MockTransport (no extra dependency, no live server) to assert:
+  - correct HTTP method, path, query params and JSON body per endpoint,
+  - parsed JSON is returned,
+  - HTTP errors and transport errors are normalised to DCNError.
+
+Async coroutines are driven with asyncio.run() so we don't depend on
+pytest-asyncio being installed in the runtime venv.
+"""
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from telegram_bot.dcn_client import DCNClient, DCNError
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+class TestHealth:
+    def test_health_ok(self):
+        def handler(req):
+            assert req.method == "GET"
+            assert req.url.path == "/api/health"
+            return httpx.Response(200, json={"status": "ok", "devices_loaded": 10})
+
+        async def go():
+            async with make_client(handler) as c:
+                return await DCNClient(base_url="http://dcn", client=c).health()
+
+        assert run(go())["status"] == "ok"
+
+
+class TestListDevices:
+    def test_passes_filters_as_query_params(self):
+        seen = {}
+
+        def handler(req):
+            seen["path"] = req.url.path
+            seen["q"] = dict(req.url.params)
+            return httpx.Response(200, json=[{"hostname": "h1"}])
+
+        async def go():
+            async with make_client(handler) as c:
+                client = DCNClient(base_url="http://dcn", client=c)
+                return await client.list_devices(site="DE-FRA", search="core")
+
+        data = run(go())
+        assert data == [{"hostname": "h1"}]
+        assert seen["path"] == "/api/devices"
+        assert seen["q"].get("site") == "DE-FRA"
+        assert seen["q"].get("search") == "core"
+
+
+class TestAsk:
+    def test_posts_prompt_to_orchestrator(self):
+        seen = {}
+
+        def handler(req):
+            seen["path"] = req.url.path
+            seen["body"] = json.loads(req.content)
+            return httpx.Response(200, json={"rendered": "ok", "agent": "IncidentAgent"})
+
+        async def go():
+            async with make_client(handler) as c:
+                client = DCNClient(base_url="http://dcn", client=c)
+                return await client.ask("why is bgp down?")
+
+        data = run(go())
+        assert seen["path"] == "/api/mv/orchestrator"
+        assert seen["body"]["prompt"] == "why is bgp down?"
+        assert data["rendered"] == "ok"
+
+
+class TestIncident:
+    def test_posts_ip_and_default_dtype(self):
+        seen = {}
+
+        def handler(req):
+            seen["path"] = req.url.path
+            seen["body"] = json.loads(req.content)
+            return httpx.Response(200, json={"ok": True})
+
+        async def go():
+            async with make_client(handler) as c:
+                client = DCNClient(base_url="http://dcn", client=c)
+                return await client.incident("10.0.0.1")
+
+        run(go())
+        assert seen["path"] == "/api/incident"
+        assert seen["body"]["ip"] == "10.0.0.1"
+        assert seen["body"]["dtype"] == "junos"
+
+
+class TestGetEndpointPaths:
+    def _path_for(self, method_name, *args):
+        seen = {}
+
+        def handler(req):
+            seen["path"] = req.url.path
+            return httpx.Response(200, json={})
+
+        async def go():
+            async with make_client(handler) as c:
+                client = DCNClient(base_url="http://dcn", client=c)
+                await getattr(client, method_name)(*args)
+
+        run(go())
+        return seen["path"]
+
+    def test_topology_path(self):
+        assert self._path_for("topology") == "/api/mv/topology"
+
+    def test_report_bgp_path(self):
+        assert self._path_for("report_bgp") == "/api/report/bgp"
+
+    def test_sites_path(self):
+        assert self._path_for("list_sites") == "/api/sites"
+
+
+class TestErrorHandling:
+    def test_http_500_raises_dcnerror(self):
+        def handler(req):
+            return httpx.Response(500, text="boom")
+
+        async def go():
+            async with make_client(handler) as c:
+                await DCNClient(base_url="http://dcn", client=c).health()
+
+        with pytest.raises(DCNError):
+            run(go())
+
+    def test_connect_error_raises_dcnerror(self):
+        def handler(req):
+            raise httpx.ConnectError("connection refused")
+
+        async def go():
+            async with make_client(handler) as c:
+                await DCNClient(base_url="http://dcn", client=c).health()
+
+        with pytest.raises(DCNError):
+            run(go())
+
+    def test_post_http_500_raises_dcnerror(self):
+        def handler(req):
+            return httpx.Response(500, text="boom")
+
+        async def go():
+            async with make_client(handler) as c:
+                await DCNClient(base_url="http://dcn", client=c).ask("x")
+
+        with pytest.raises(DCNError):
+            run(go())

--- a/src/tests/test_tg_config.py
+++ b/src/tests/test_tg_config.py
@@ -1,0 +1,49 @@
+"""
+test_tg_config.py — immutable env-driven configuration for the ChatOps bot.
+
+Config is the boundary where misconfiguration must fail loudly (no token => no
+bot) and where the security-relevant allowlist is parsed.
+"""
+
+import pytest
+
+from telegram_bot.config import BotConfig
+
+
+def test_from_env_minimal_parses_token_and_allowlist():
+    cfg = BotConfig.from_env(
+        {"TELEGRAM_BOT_TOKEN": "abc:123", "TELEGRAM_ALLOWED_CHAT_IDS": "1,2"}
+    )
+    assert cfg.token == "abc:123"
+    assert cfg.allowed_chat_ids == frozenset({1, 2})
+    assert cfg.dcn_api_url == "http://localhost:5757"  # default
+
+
+def test_token_is_required():
+    with pytest.raises(ValueError):
+        BotConfig.from_env({})
+
+
+def test_trailing_slash_stripped_from_api_url():
+    cfg = BotConfig.from_env(
+        {"TELEGRAM_BOT_TOKEN": "t", "DCN_API_URL": "http://x:5757/"}
+    )
+    assert cfg.dcn_api_url == "http://x:5757"
+
+
+def test_admins_and_rate_limit_parsed():
+    cfg = BotConfig.from_env(
+        {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_ADMIN_CHAT_IDS": "9",
+            "TELEGRAM_RATE_LIMIT_PER_MIN": "5",
+        }
+    )
+    assert cfg.admin_chat_ids == frozenset({9})
+    assert cfg.rate_limit_per_min == 5
+
+
+def test_config_is_immutable():
+    cfg = BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t"})
+    with pytest.raises(Exception):
+        cfg.token = "tampered"  # frozen dataclass -> FrozenInstanceError

--- a/src/tests/test_tg_config.py
+++ b/src/tests/test_tg_config.py
@@ -47,3 +47,22 @@ def test_config_is_immutable():
     cfg = BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t"})
     with pytest.raises(Exception):
         cfg.token = "tampered"  # frozen dataclass -> FrozenInstanceError
+
+
+def test_timeouts_parsed():
+    """Sourcery #7: request/ask timeout env vars are parsed as floats."""
+    cfg = BotConfig.from_env(
+        {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "TELEGRAM_REQUEST_TIMEOUT": "12",
+            "TELEGRAM_ASK_TIMEOUT": "34",
+        }
+    )
+    assert cfg.request_timeout == 12.0
+    assert cfg.ask_timeout == 34.0
+
+
+def test_timeout_defaults():
+    cfg = BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t"})
+    assert cfg.request_timeout == 30.0
+    assert cfg.ask_timeout == 120.0

--- a/src/tests/test_tg_config.py
+++ b/src/tests/test_tg_config.py
@@ -66,3 +66,12 @@ def test_timeout_defaults():
     cfg = BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t"})
     assert cfg.request_timeout == 30.0
     assert cfg.ask_timeout == 120.0
+
+
+def test_report_timeout_parsed_and_default():
+    """Sourcery re-review #2: the long-running report/incident timeout is configurable."""
+    cfg = BotConfig.from_env(
+        {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_REPORT_TIMEOUT": "45"}
+    )
+    assert cfg.report_timeout == 45.0
+    assert BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t"}).report_timeout == 300.0

--- a/src/tests/test_tg_formatting.py
+++ b/src/tests/test_tg_formatting.py
@@ -1,0 +1,111 @@
+"""
+test_tg_formatting.py — Telegram ChatOps bot: API-JSON -> chat-message renderers.
+
+Pure functions that turn DCN API payloads into Telegram-safe text. They must:
+  - never exceed Telegram's 4096-char message limit (truncate),
+  - tolerate missing/partial fields (defensive .get usage),
+  - degrade to a readable generic render for endpoints whose schema we don't pin.
+"""
+
+from telegram_bot.formatting import (
+    TELEGRAM_MAX,
+    truncate,
+    format_health,
+    format_sites,
+    format_devices,
+    format_ask,
+    format_report,
+    format_error,
+)
+
+
+class TestTruncate:
+    def test_short_text_unchanged(self):
+        assert truncate("hello", 100) == "hello"
+
+    def test_long_text_truncated_within_limit(self):
+        out = truncate("x" * 5000, 100)
+        assert len(out) <= 100
+        assert out.endswith("…")
+
+    def test_default_limit_is_telegram_max(self):
+        assert len(truncate("y" * 10000)) <= TELEGRAM_MAX
+
+
+class TestFormatHealth:
+    def test_ok_status_and_device_count(self):
+        out = format_health(
+            {"status": "ok", "devices_loaded": 10, "timestamp": "2026-05-29T11:00:00"}
+        )
+        assert "ok" in out.lower()
+        assert "10" in out
+
+    def test_missing_fields_safe(self):
+        out = format_health({})
+        assert isinstance(out, str) and out.strip()
+
+
+class TestFormatSites:
+    def test_plain_list(self):
+        out = format_sites(["DE-FRA", "UK-LON"])
+        assert "DE-FRA" in out and "UK-LON" in out
+
+    def test_wrapped_in_dict(self):
+        out = format_sites({"sites": ["NL-AMS"]})
+        assert "NL-AMS" in out
+
+    def test_empty_is_string(self):
+        assert isinstance(format_sites([]), str)
+
+
+class TestFormatDevices:
+    SAMPLE = [
+        {"hostname": "de-fra-core-01", "site": "DE-FRA", "type": "frr", "ip": "10.0.0.1"},
+        {"hostname": "uk-lon-core-01", "site": "UK-LON", "type": "frr", "ip": "10.0.0.2"},
+    ]
+
+    def test_lists_hostnames(self):
+        out = format_devices(self.SAMPLE)
+        assert "de-fra-core-01" in out and "uk-lon-core-01" in out
+
+    def test_respects_limit_and_reports_overflow(self):
+        many = [{"hostname": f"h{i}"} for i in range(100)]
+        out = format_devices(many, limit=10)
+        assert "h0" in out and "h9" in out
+        assert "h99" not in out
+        assert "90 more" in out
+
+    def test_wrapped_in_dict(self):
+        out = format_devices({"devices": self.SAMPLE})
+        assert "de-fra-core-01" in out
+
+
+class TestFormatAsk:
+    def test_prefers_rendered_field(self):
+        out = format_ask({"rendered": "All BGP peers up.", "agent": "IncidentAgent"})
+        assert "All BGP peers up." in out
+
+    def test_falls_back_to_output(self):
+        assert "hi there" in format_ask({"output": "hi there"})
+
+    def test_error_payload(self):
+        assert "prompt required" in format_ask({"error": "prompt required"})
+
+
+class TestFormatReport:
+    def test_dict_renders_values(self):
+        out = format_report("BGP sessions", {"total_peers": 36, "down_sessions": 0})
+        assert "BGP sessions" in out and "36" in out
+
+    def test_error_dict(self):
+        out = format_report("BGP sessions", {"error": "backend down"})
+        assert "backend down" in out
+
+    def test_list_payload(self):
+        out = format_report("Topology", [{"node": "a"}])
+        assert "Topology" in out
+
+
+class TestFormatError:
+    def test_contains_message(self):
+        assert "device unreachable" in format_error("device unreachable")

--- a/src/tests/test_tg_formatting.py
+++ b/src/tests/test_tg_formatting.py
@@ -109,3 +109,29 @@ class TestFormatReport:
 class TestFormatError:
     def test_contains_message(self):
         assert "device unreachable" in format_error("device unreachable")
+
+
+class TestTruncateEdges:
+    def test_limit_zero_returns_empty(self):
+        assert truncate("hello", 0) == ""
+
+    def test_limit_one_no_ellipsis(self):
+        out = truncate("hello", 1)
+        assert out == "h"
+        assert "…" not in out
+
+
+class TestErrorDetection:
+    """Sourcery #1: falsy error values (""/0) must still be flagged as errors."""
+
+    def test_empty_string_error_is_flagged(self):
+        out = format_health({"error": ""})
+        assert out.startswith("⚠️")  # error path, not normal render
+
+    def test_zero_error_is_flagged(self):
+        out = format_sites({"error": 0})
+        assert out.startswith("⚠️")
+
+    def test_devices_error_is_flagged(self):
+        out = format_devices({"error": "boom"})
+        assert out.startswith("⚠️") and "boom" in out


### PR DESCRIPTION
## Summary

Adds a **bi-directional Telegram ChatOps interface** for the DCN Network Tool — a thin, read-only front-end over the *existing* Flask/MCP API. It adds **no new backend capability**; it gives operators a fourth way to reach the tools that already exist (web UI, MCP/Claude, push alerts) directly from a phone.

Motivation: the stack already had the web dashboard and the MCP/Claude interface but only *one-way* Telegram alerts. This fills the missing interactive **phone** interface — "engineers shouldn't be locked into one interface."

## Commands

| Command | Backend endpoint | Purpose |
|---|---|---|
| `/health` | `GET /api/health` | API + lab health |
| `/sites` | `GET /api/sites` | List datacenter sites |
| `/devices [filter]` | `GET /api/devices` | List devices (optional hostname filter) |
| `/topo` | `GET /api/mv/topology` | Multivendor topology snapshot |
| `/bgp [site]` | `GET /api/report/bgp` | Network-wide BGP session health |
| `/incident <ip>` | `POST /api/incident` | Collect incident data for a device |
| `/ask <question>` | `POST /api/mv/orchestrator` | Free-text Q&A via the existing Qwen3→Claude orchestrator |
| `/help` | — | Help |

## Architecture (testable split)

```
src/telegram_bot/
  config.py      immutable env-driven settings
  auth.py        fail-closed allowlist + RBAC + sliding-window rate limiter   (pure)
  dcn_client.py  async httpx client over the DCN API (DCNError normalisation)
  formatting.py  API JSON -> Telegram-safe text (length-capped, defensive)    (pure)
  bot.py         python-telegram-bot v21+ wiring (guard, audit log, errors)
```

`auth`, `config`, `dcn_client`, `formatting` carry no Telegram dependency, so the logic is unit-tested without it.

## Security

- **Fail-closed allowlist** on every command (empty `TELEGRAM_ALLOWED_CHAT_IDS` ⇒ deny all).
- Per-chat **sliding-window rate limiting**.
- **Audit logging** of every command and denial (consistent with the GAIT/AEGIS evidence ethos).
- **Long-polling** — no inbound port / public TLS.
- **Read + diagnose only** — no config push from chat by design.
- ⚠️ **Air-gap boundary**: Telegram relays via Telegram's cloud — fine for the lab/DCN tier, but must not carry a regulated air-gapped AEGIS customer's topology/config. Dashboard-only or self-hosted Matrix there.

## Deployment

- `telegram_bot/install_launchd.sh` creates `src/.venv`, installs deps, renders the plist from `*.plist.template`, and bootstraps a launchd user agent. Dormant-safe (`KeepAlive.SuccessfulExit=false` + wrapper exits 0 when unconfigured ⇒ no crash-loop).
- Opt-in deps in `telegram_bot/requirements.txt` (`python-telegram-bot>=21.6`, `httpx`) — not pulled in by the main app.

## Test plan

- [x] `pytest tests/test_tg_*.py` — **65 tests pass, 88% coverage** (auth/config 100%, dcn_client 95%, formatting 89%). Built test-first (RED→GREEN).
- [x] Import/build smoke check against python-telegram-bot 22.7 on Python 3.14.
- [x] launchd agent bootstrapped and verified dormant-safe (exit 0, no crash-loop, empty err.log).
- [ ] Live smoke test with a real `TELEGRAM_BOT_TOKEN` + allowlisted chat id against a running DCN API (`/health`, `/ask`).

## Notes

- Pure addition — no existing tracked files modified.
- Does **not** touch the unrelated in-progress change to `src/multivendor_extensions.py`.

## Summary by Sourcery

Add a Telegram-based ChatOps front-end for the DCN Network Tool, including bot wiring, configuration, authorization, HTTP client, formatting utilities, deployment scripts, and comprehensive tests, without changing existing backend capabilities.

New Features:
- Introduce a Telegram ChatOps bot that exposes existing DCN Network Tool endpoints via read-only chat commands.
- Add configurable, env-driven settings for the Telegram bot, including API URL, timeouts, rate limits, and chat/admin allowlists.
- Provide an async DCN API client used by the bot to call existing health, inventory, topology, BGP, incident, and orchestrator endpoints.
- Implement pure formatting helpers to render DCN API JSON responses into Telegram-safe, length-capped messages.

Enhancements:
- Add security-focused auth and rate-limiting utilities with fail-closed chat allowlists and per-chat sliding-window limits for bot access.
- Add a launchd installation script and run wrapper to manage the bot as an opt-in, long-polling user agent without impacting the main app.
- Document the Telegram ChatOps bot architecture, commands, security model, and usage in a dedicated README.

Build:
- Declare opt-in Telegram bot runtime dependencies (python-telegram-bot and httpx) in a separate requirements file so they are not required by the core application.

Tests:
- Add unit test suites for bot handler wiring and guards, DCN API client behaviour, message formatting, auth logic, and configuration parsing to ensure high coverage and regression safety.