### PR TITLE
fix(security): harden ChatOps bot + MCP client per ultrareview (12 findings)

### DIFF
--- a/src/mcp_dcn_server.py
+++ b/src/mcp_dcn_server.py
@@ -7,24 +7,26 @@ Usage:
     python mcp_dcn_server.py
 
 Environment:
-    DCN_API_URL  — Base URL of the DCN Network Tool API (default: http://localhost:5757)
+    DCN_API_URL    — Base URL of the DCN Network Tool API (default: http://localhost:5757)
+    MVLAB_API_KEY  — Shared secret sent as X-API-Key for the API's mutating endpoints
 """
 import os
 import json
 import urllib.request
 import urllib.error
+import urllib.parse
 from mcp.server.fastmcp import FastMCP
 
 DCN_URL = os.environ.get("DCN_API_URL", "http://localhost:5757")
-DCN_API_KEY = os.environ.get("DCN_API_KEY", "")
+MVLAB_API_KEY = os.environ.get("MVLAB_API_KEY", "")
 
 
 def _auth_headers(base=None):
-    """Attach X-API-Key when DCN_API_KEY is set — the DCN API gates mutating
+    """Attach X-API-Key when MVLAB_API_KEY is set — the DCN API gates mutating
     endpoints behind this shared secret."""
     headers = dict(base or {})
-    if DCN_API_KEY:
-        headers["X-API-Key"] = DCN_API_KEY
+    if MVLAB_API_KEY:
+        headers["X-API-Key"] = MVLAB_API_KEY
     return headers
 
 
@@ -62,10 +64,11 @@ def _post(path: str, body: dict, timeout: int = 180) -> dict:
 def _get(path: str, params: dict = None, timeout: int = 30) -> str:
     """GET from DCN API and return raw text."""
     url = f"{DCN_URL}{path}"
-    if params:
-        qs = "&".join(f"{k}={v}" for k, v in params.items() if v)
-        if qs:
-            url += f"?{qs}"
+    # urlencode percent-encodes every value, so caller-supplied strings containing
+    # &, =, #, %, or spaces can't splice extra query params or break the URL.
+    qs = urllib.parse.urlencode({k: v for k, v in (params or {}).items() if v})
+    if qs:
+        url += f"?{qs}"
     try:
         req = urllib.request.Request(url, headers=_auth_headers())
         with urllib.request.urlopen(req, timeout=timeout) as resp:

--- a/src/telegram_bot/bot.py
+++ b/src/telegram_bot/bot.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import re
 from typing import Awaitable, Callable
 
 import httpx
@@ -35,6 +36,18 @@ from . import formatting as fmt
 log = logging.getLogger("dcn.telegram")
 
 Handler = Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[None]]
+
+# Decorative Markdown the formatters inject; stripped for the plain-text fallback
+# when Telegram rejects the entities. We strip ``*`` (bold), backtick code spans
+# and ``` fences only — never ``_`` or brackets, which appear in real device
+# hostnames (de_fra_core_01) and JSON keys we must keep readable.
+_MD_FENCE = re.compile(r"```")
+_MD_DECORATION = re.compile(r"[*`]")
+
+
+def _to_plain(text: str) -> str:
+    """Strip injected Markdown decoration so the plain-text fallback reads cleanly."""
+    return _MD_DECORATION.sub("", _MD_FENCE.sub("", text))
 
 _HELP = (
     "🛰️ *DCN ChatOps*\n"
@@ -144,7 +157,7 @@ class ChatOpsBot:
         try:
             await msg.reply_text(text, parse_mode=ParseMode.MARKDOWN)
         except BadRequest:
-            await msg.reply_text(text)
+            await msg.reply_text(_to_plain(text))
 
     # ── command handlers ───────────────────────────────────────────────────────
     async def cmd_help(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -203,7 +216,7 @@ class ChatOpsBot:
         try:
             await placeholder.edit_text(text, parse_mode=ParseMode.MARKDOWN)
         except BadRequest:
-            await placeholder.edit_text(text)
+            await placeholder.edit_text(_to_plain(text))
 
     async def _run(
         self,
@@ -231,10 +244,12 @@ class ChatOpsBot:
 
 
 def _silence_token_logging() -> None:
-    """Stop httpx/httpcore from logging request URLs at INFO — those URLs embed
-    the bot token (``.../bot<TOKEN>/getUpdates``), which must never hit a log file."""
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    """Keep the bot token out of logs. httpx logs the request URL
+    (``.../bot<TOKEN>/getUpdates``) at INFO, and telegram.Bot logs its
+    token-bearing base URL at DEBUG — neither must reach a log file, even if a
+    developer raises the root level to DEBUG for troubleshooting."""
+    for name in ("httpx", "httpcore", "telegram"):
+        logging.getLogger(name).setLevel(logging.WARNING)
 
 
 def main() -> None:

--- a/src/telegram_bot/config.py
+++ b/src/telegram_bot/config.py
@@ -2,27 +2,51 @@
 config.py — immutable, env-driven configuration for the ChatOps bot.
 
 Loaded once at startup. Missing token is fatal; the chat-ID allowlist is parsed
-here so a bad value fails loudly before the bot ever goes online.
+here so a bad value fails loudly before the bot ever goes online. Numeric vars go
+through ``_num_env`` so a misconfigured value names the offending variable rather
+than raising an opaque ``invalid literal for int()``.
 """
 
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
-from typing import Mapping
+from dataclasses import dataclass, field
+from typing import Callable, Mapping, TypeVar
 
 from .auth import parse_chat_ids
 
 DEFAULT_DCN_API_URL = "http://localhost:5757"
 
+_Num = TypeVar("_Num", int, float)
+
+
+def _num_env(
+    env: Mapping[str, str], key: str, default: str, conv: Callable[[str], _Num]
+) -> _Num:
+    """Read a numeric env var, failing loudly with the variable name on bad input.
+
+    Mirrors ``parse_chat_ids``' convention: a misconfigured numeric setting names
+    the offending variable (and value) instead of an opaque stdlib ValueError that
+    hides which of the four numeric vars is actually wrong.
+    """
+    raw = env.get(key, default)
+    try:
+        return conv(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{key} must be a valid {conv.__name__}, got {raw!r}"
+        ) from exc
+
 
 @dataclass(frozen=True)
 class BotConfig:
-    token: str
+    # token and dcn_api_key are secrets: repr=False keeps them out of tracebacks
+    # and debug output (e.g. a locals-dumping error reporter) regardless of level.
+    token: str = field(repr=False)
     allowed_chat_ids: frozenset[int]
     admin_chat_ids: frozenset[int]
     dcn_api_url: str = DEFAULT_DCN_API_URL
-    dcn_api_key: str = ""  # X-API-Key for the DCN API's mutating endpoints
+    dcn_api_key: str = field(default="", repr=False)  # X-API-Key for mutating endpoints
     rate_limit_per_min: int = 20
     request_timeout: float = 30.0
     ask_timeout: float = 120.0
@@ -42,8 +66,8 @@ class BotConfig:
             admin_chat_ids=parse_chat_ids(env.get("TELEGRAM_ADMIN_CHAT_IDS")),
             dcn_api_url=(env.get("DCN_API_URL") or DEFAULT_DCN_API_URL).rstrip("/"),
             dcn_api_key=(env.get("MVLAB_API_KEY") or "").strip(),
-            rate_limit_per_min=int(env.get("TELEGRAM_RATE_LIMIT_PER_MIN", "20")),
-            request_timeout=float(env.get("TELEGRAM_REQUEST_TIMEOUT", "30")),
-            ask_timeout=float(env.get("TELEGRAM_ASK_TIMEOUT", "120")),
-            report_timeout=float(env.get("TELEGRAM_REPORT_TIMEOUT", "300")),
+            rate_limit_per_min=_num_env(env, "TELEGRAM_RATE_LIMIT_PER_MIN", "20", int),
+            request_timeout=_num_env(env, "TELEGRAM_REQUEST_TIMEOUT", "30", float),
+            ask_timeout=_num_env(env, "TELEGRAM_ASK_TIMEOUT", "120", float),
+            report_timeout=_num_env(env, "TELEGRAM_REPORT_TIMEOUT", "300", float),
         )

--- a/src/telegram_bot/dcn_client.py
+++ b/src/telegram_bot/dcn_client.py
@@ -11,7 +11,7 @@ friendly message instead of leaking a stack trace into a chat.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
@@ -34,7 +34,9 @@ class DCNClient:
     timeout: float = 30.0
     ask_timeout: float = 120.0
     report_timeout: float = 300.0
-    api_key: str = ""  # sent as X-API-Key; DCN API gates mutating endpoints on it
+    # sent as X-API-Key; DCN API gates mutating endpoints on it. repr=False keeps
+    # the secret out of tracebacks / locals-dumping error reporters.
+    api_key: str = field(default="", repr=False)
 
     def _headers(self) -> dict | None:
         return {"X-API-Key": self.api_key} if self.api_key else None

--- a/src/tests/test_mcp_dcn_get.py
+++ b/src/tests/test_mcp_dcn_get.py
@@ -1,0 +1,56 @@
+"""
+test_mcp_dcn_get.py — the stdlib MCP client must URL-encode query-param values.
+
+Ultrareview #4 (HIGH): _get() builds the query string from caller/LLM-supplied
+tool arguments. Without percent-encoding, a value like "DE-FRA&admin=1" splices a
+second query parameter into the request. urlencode() neutralizes that.
+
+Skipped automatically if the MCP SDK isn't installed in the running interpreter.
+"""
+
+import importlib
+
+import pytest
+
+pytest.importorskip("mcp.server.fastmcp")  # MCP SDK required to import the server
+mcp_dcn_server = importlib.import_module("mcp_dcn_server")
+
+
+class _FakeResp:
+    def __init__(self, body: str) -> None:
+        self._body = body.encode()
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+def _capture_url(monkeypatch) -> dict:
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _FakeResp("ok")
+
+    monkeypatch.setattr(mcp_dcn_server.urllib.request, "urlopen", fake_urlopen)
+    return captured
+
+
+def test_get_url_encodes_param_values(monkeypatch):
+    captured = _capture_url(monkeypatch)
+    mcp_dcn_server._get("/api/devices", {"site": "DE-FRA&admin=1"})
+    # the injected '&admin=1' must be percent-encoded, never spliced as a 2nd param
+    assert "admin=1" not in captured["url"]
+    assert "DE-FRA%26admin%3D1" in captured["url"]
+
+
+def test_get_drops_empty_params_but_keeps_truthy(monkeypatch):
+    captured = _capture_url(monkeypatch)
+    mcp_dcn_server._get("/api/devices", {"site": "", "role": "core"})
+    assert "site=" not in captured["url"]
+    assert "role=core" in captured["url"]

--- a/src/tests/test_tg_auth.py
+++ b/src/tests/test_tg_auth.py
@@ -94,6 +94,21 @@ class TestRateLimiter:
         assert rl.allow(2) is True  # different chat is unaffected
         assert rl.allow(1) is False
 
+    def test_window_boundary_is_inclusive_eviction(self):
+        """Ultrareview #8: pins the eviction predicate `bucket[0] <= cutoff`.
+
+        A hit at exactly window_seconds ago is evicted (next call allowed); just
+        shy of the boundary it still counts (blocked). Catches a silent off-by-one
+        flip from `<=` to `<`. max=1 makes each result a pure function of eviction."""
+        clock = [1000.0]
+        rl = RateLimiter(1, 60, clock=lambda: clock[0])
+        assert rl.allow(7) is True       # records hit at t=1000
+        assert rl.allow(7) is False      # at limit within the window
+        clock[0] = 1000.0 + 59.999       # just inside the window
+        assert rl.allow(7) is False      # prior hit still counts
+        clock[0] = 1000.0 + 60.0         # exactly window_seconds after the hit
+        assert rl.allow(7) is True       # prior hit evicted (cutoff inclusive)
+
 
 class TestRateLimiterMisconfiguration:
     """Sourcery #2: a non-positive limit must not silently block everyone.

--- a/src/tests/test_tg_bot.py
+++ b/src/tests/test_tg_bot.py
@@ -103,8 +103,11 @@ class TestAuthGuard:
 
         guarded = bot._guard(inner)
         asyncio.run(guarded(FakeUpdate(1, "/health"), None))  # allowed
-        asyncio.run(guarded(FakeUpdate(1, "/health"), None))  # blocked
+        blocked = FakeUpdate(1, "/health")
+        asyncio.run(guarded(blocked, None))  # blocked
         assert calls == [True]  # only the first ran
+        # Ultrareview #7: the throttled user must actually be told they were limited.
+        assert any("Rate limit" in str(r) for r in blocked.effective_message.replies)
 
 
 # ── Fakes for exercising command handlers without a live DCN API ─────────────
@@ -166,6 +169,25 @@ class FlakyMessage(FakeMessage):
             raise BadRequest("can't parse entities")
         self.replies.append(text)
         return FakeMessage()
+
+
+class FlakyPlaceholder(FakeMessage):
+    """edit_text rejects the first Markdown attempt, accepts the plain retry."""
+
+    async def edit_text(self, text, **kwargs):
+        if "parse_mode" in kwargs:
+            raise BadRequest("can't parse entities")
+        self.replies.append(("edit", text))
+        return self
+
+
+class FlakyPlaceholderParent(FakeMessage):
+    """reply_text hands back a FlakyPlaceholder as the editable placeholder."""
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.child = FlakyPlaceholder()
+        return self.child
 
 
 class TestCommandHandlers:
@@ -250,6 +272,17 @@ class TestCommandHandlers:
         assert placeholder is not None
         assert any("orchestrator down" in str(e) for e in placeholder.replies)
 
+    def test_ask_error_falls_back_to_plain_text_in_placeholder(self):
+        # Ultrareview #6: when the Markdown placeholder edit is rejected, the
+        # plain-text retry must still deliver the error text to the user.
+        bot = self._ready_bot(FakeAskErrorDCN())
+        upd = FakeUpdate(1, "/ask boom")
+        upd.effective_message = FlakyPlaceholderParent("/ask boom")
+        asyncio.run(bot.cmd_ask(upd, FakeContext(["boom"])))
+        placeholder = upd.effective_message.child
+        assert placeholder is not None
+        assert any("orchestrator down" in str(e) for e in placeholder.replies)
+
 
 class TestGuardEdgeCases:
     """Sourcery #4: guard must handle updates missing chat / message."""
@@ -281,12 +314,23 @@ class TestGuardEdgeCases:
 
 
 class TestSendFallback:
-    def test_falls_back_to_plain_text_on_bad_request(self):
+    def test_falls_back_to_stripped_plain_text_on_bad_request(self):
+        # Ultrareview #3: the fallback strips decorative Markdown (* and backticks)
+        # instead of re-sending raw markup that Telegram renders literally.
         bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
         upd = FakeUpdate(1, "/health")
         upd.effective_message = FlakyMessage()
-        asyncio.run(bot._send(upd, "*markdown*"))
-        assert "*markdown*" in upd.effective_message.replies
+        asyncio.run(bot._send(upd, "*markdown* `code`"))
+        assert "markdown code" in upd.effective_message.replies
+        assert "*markdown*" not in upd.effective_message.replies
+
+    def test_fallback_preserves_underscores_in_hostnames(self):
+        # Underscores belong to real device hostnames / JSON keys — never stripped.
+        bot = _bot(TELEGRAM_ALLOWED_CHAT_IDS="1")
+        upd = FakeUpdate(1, "/devices")
+        upd.effective_message = FlakyMessage()
+        asyncio.run(bot._send(upd, "`de_fra_core_01` is up"))
+        assert "de_fra_core_01 is up" in upd.effective_message.replies
 
 
 class TestLoggingHygiene:
@@ -302,6 +346,16 @@ class TestLoggingHygiene:
         _silence_token_logging()
         assert logging.getLogger("httpx").level == logging.WARNING
         assert logging.getLogger("httpcore").level == logging.WARNING
+
+    def test_silence_covers_telegram_namespace(self):
+        # Ultrareview #2: telegram.Bot logs its token-bearing base URL at DEBUG,
+        # so the parent 'telegram' logger must be raised to WARNING too.
+        import logging
+        from telegram_bot.bot import _silence_token_logging
+
+        logging.getLogger("telegram").setLevel(logging.DEBUG)
+        _silence_token_logging()
+        assert logging.getLogger("telegram").level == logging.WARNING
 
 
 class TestAuditLogRedaction:

--- a/src/tests/test_tg_config.py
+++ b/src/tests/test_tg_config.py
@@ -75,3 +75,34 @@ def test_report_timeout_parsed_and_default():
     )
     assert cfg.report_timeout == 45.0
     assert BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t"}).report_timeout == 300.0
+
+
+def test_dcn_api_key_parsed_and_default():
+    """Ultrareview #12: the X-API-Key for the DCN API's mutating endpoints is read
+    from MVLAB_API_KEY (whitespace-stripped) and defaults to empty when absent.
+    Pins the env-var name so an operator following .env.example actually gets a key."""
+    cfg = BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t", "MVLAB_API_KEY": "  mykey  "})
+    assert cfg.dcn_api_key == "mykey"
+    assert BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t"}).dcn_api_key == ""
+
+
+def test_bad_numeric_env_names_the_offending_variable():
+    """Ultrareview #1: a malformed numeric var fails loudly, naming the variable
+    (not just an opaque 'invalid literal for int()')."""
+    with pytest.raises(ValueError, match="TELEGRAM_RATE_LIMIT_PER_MIN"):
+        BotConfig.from_env(
+            {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_RATE_LIMIT_PER_MIN": "twenty"}
+        )
+    with pytest.raises(ValueError, match="TELEGRAM_ASK_TIMEOUT"):
+        BotConfig.from_env({"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_ASK_TIMEOUT": "30s"})
+
+
+def test_secrets_excluded_from_repr():
+    """Ultrareview #5: token and dcn_api_key must never appear in repr(), so they
+    can't leak via a traceback or a locals-dumping error reporter."""
+    cfg = BotConfig.from_env(
+        {"TELEGRAM_BOT_TOKEN": "123456:SECRET-TOKEN", "MVLAB_API_KEY": "supersecretkey"}
+    )
+    text = repr(cfg)
+    assert "SECRET-TOKEN" not in text
+    assert "supersecretkey" not in text

--- a/src/tests/test_tg_formatting.py
+++ b/src/tests/test_tg_formatting.py
@@ -7,6 +7,8 @@ Pure functions that turn DCN API payloads into Telegram-safe text. They must:
   - degrade to a readable generic render for endpoints whose schema we don't pin.
 """
 
+import pytest
+
 from telegram_bot.formatting import (
     TELEGRAM_MAX,
     truncate,
@@ -37,8 +39,17 @@ class TestFormatHealth:
         out = format_health(
             {"status": "ok", "devices_loaded": 10, "timestamp": "2026-05-29T11:00:00"}
         )
+        assert out.startswith("✅")  # ok branch of the icon selector
         assert "ok" in out.lower()
         assert "10" in out
+
+    def test_degraded_status_shows_warning_icon(self):
+        """Ultrareview #10: a non-ok status renders ⚠️, not ✅ — an on-call engineer
+        must not see a green check on a degraded fabric."""
+        out = format_health({"status": "degraded", "devices_loaded": 5})
+        assert out.startswith("⚠️")
+        assert "✅" not in out
+        assert "degraded" in out
 
     def test_missing_fields_safe(self):
         out = format_health({})
@@ -79,6 +90,13 @@ class TestFormatDevices:
         out = format_devices({"devices": self.SAMPLE})
         assert "de-fra-core-01" in out
 
+    def test_bare_string_devices(self):
+        """Ultrareview #11: non-dict list elements render via the `• {dev}` else
+        branch — pin the bullet so an accidental removal is caught."""
+        out = format_devices(["router-a", "router-b"])
+        assert "• router-a" in out and "• router-b" in out
+        assert "Devices (2)" in out
+
 
 class TestFormatAsk:
     def test_prefers_rendered_field(self):
@@ -90,6 +108,21 @@ class TestFormatAsk:
 
     def test_error_payload(self):
         assert "prompt required" in format_ask({"error": "prompt required"})
+
+    def test_first_priority_key_wins_over_lower(self):
+        """Ultrareview #9: 'rendered' outranks 'output' even when both are present
+        — pins the ordered-tuple semantics against an accidental reorder."""
+        out = format_ask({"output": "second", "rendered": "first"})
+        assert "first" in out
+        assert "second" not in out
+
+    @pytest.mark.parametrize("key", ["answer", "result", "summary"])
+    def test_lower_priority_keys_used_when_alone(self, key):
+        assert "lonely value" in format_ask({key: "lonely value"})
+
+    def test_unrecognized_dict_falls_back_to_json_dump(self):
+        out = format_ask({"unknown_field": 42})
+        assert "unknown_field" in out and "42" in out
 
 
 class TestFormatReport:


### PR DESCRIPTION
## Summary

Adversarial multi-agent review (12 adversarially-confirmed findings) of this session's Telegram ChatOps bot + X-API-Key work. All fixes are minimal, behavior-preserving, and accompanied by regression tests.

### Production fixes
| Sev | File | Fix |
|-----|------|-----|
| **HIGH** | `mcp_dcn_server.py` | `_get()` query string was raw-concatenated (`f"{k}={v}"`) — caller/LLM-supplied values containing `&`/`=`/`#` could splice extra query params. Now uses `urllib.parse.urlencode`. |
| med | `mcp_dcn_server.py` | Completed the `DCN_API_KEY` → `MVLAB_API_KEY` rename the cleanup branch missed, so the MCP client matches the bot/server env-var name (operators set one name everywhere). |
| med (security) | `bot.py` | `_silence_token_logging` now also silences the `telegram` namespace — `telegram.Bot` logs its token-bearing base URL at DEBUG. |
| med (security) | `config.py`, `dcn_client.py` | `token`, `dcn_api_key`, `api_key` marked `field(repr=False)` so secrets can't leak via `repr()`/tracebacks/locals-dumping reporters. |
| low | `bot.py` | Markdown-fail plain-text fallback now strips decorative markup (`*`, backtick, fences) instead of re-sending raw markup as literal text. Underscores/brackets preserved (real hostnames/JSON keys). |
| med | `config.py` | Numeric env vars fail loudly **naming the offending variable** instead of an opaque `invalid literal for int()`. |

### Test coverage (+18 cases, 106 passing)
Rate-limit denial reply, `/ask` placeholder Markdown-fallback path, `telegram` log silence, sliding-window boundary (exact-cutoff eviction), `format_ask` priority order + JSON fallback, `format_health` warning icon, `format_devices` bare-string elements, `MVLAB_API_KEY` round-trip, named numeric error, secret `repr` redaction, and the `_get` URL-encode injection (verified: `DE-FRA&admin=1` → `DE-FRA%26admin%3D1`).

### Test plan
- [x] `pytest tests/test_tg_*.py tests/test_mcp_dcn_get.py` → **106 passed**
- [ ] Sourcery AI auto-review

## Summary by Sourcery

Harden the Telegram ChatOps bot and MCP DCN client against logging and query-string injection issues while improving numeric config validation and test coverage.

Bug Fixes:
- Ensure ChatOps bot rate limiting both blocks excess requests and informs users when they are throttled.
- Fix Markdown error-path handling so placeholder edits and message sends fall back to a clean plain-text version when Telegram rejects entities.
- Prevent leakage of bot tokens and API keys by raising logging levels for the telegram namespace and excluding secret fields from repr output in bot and DCN client configs.
- Align MCP DCN client and bot configuration to use the MVLAB_API_KEY environment variable for X-API-Key authentication instead of the old DCN_API_KEY name.
- Ensure MCP DCN client _get() URL-encodes query parameters to prevent caller-supplied values from injecting additional query arguments.
- Improve numeric environment variable parsing so malformed values raise clear errors naming the offending variable.

Enhancements:
- Refine health, devices, and ask output formatting, including warning icons for degraded status, consistent bullet rendering, and deterministic field-priority rules.
- Introduce a helper to strip decorative Markdown while preserving meaningful characters in plain-text fallbacks.

Tests:
- Add regression tests for rate-limit eviction boundaries, user-facing throttling replies, Markdown fallback behavior, log-silencing of telegram, secret redaction from repr, numeric env error messaging, MVLAB_API_KEY parsing, formatting behavior, and MCP DCN client query encoding.