### PR TITLE
feat: bake eAPI into cEOS startup-configs for NAPALM

### DIFF
--- a/containerlab-multivendor/configs/leaf/leaf1-ceos.cfg
+++ b/containerlab-multivendor/configs/leaf/leaf1-ceos.cfg
@@ -4,6 +4,15 @@
 !
 hostname leaf1
 !
+!
+! ── eAPI for NAPALM (added 2026-06-06) ──
+aaa authorization exec default local
+!
+username admin privilege 15 role network-admin secret admin
+!
+management api http-commands
+   no shutdown
+!
 snmp-server community GESH-DC1-RO ro
 snmp-server host 172.20.20.1 version 2c GESH-DC1-RO udp-port 1162
 snmp-server enable traps bgp

--- a/containerlab-multivendor/configs/leaf/leaf4-ceos.cfg
+++ b/containerlab-multivendor/configs/leaf/leaf4-ceos.cfg
@@ -4,6 +4,15 @@
 !
 hostname leaf4
 !
+!
+! ── eAPI for NAPALM (added 2026-06-06) ──
+aaa authorization exec default local
+!
+username admin privilege 15 role network-admin secret admin
+!
+management api http-commands
+   no shutdown
+!
 snmp-server community GESH-DC1-RO ro
 snmp-server host 172.20.20.1 version 2c GESH-DC1-RO udp-port 1162
 snmp-server enable traps bgp

--- a/containerlab-multivendor/configs/spine/spine2-ceos.cfg
+++ b/containerlab-multivendor/configs/spine/spine2-ceos.cfg
@@ -3,6 +3,15 @@
 !
 hostname spine2
 !
+!
+! ── eAPI for NAPALM (added 2026-06-06) ──
+aaa authorization exec default local
+!
+username admin privilege 15 role network-admin secret admin
+!
+management api http-commands
+   no shutdown
+!
 snmp-server contact gesh-noc@gesh.io
 snmp-server location GESH-DC1-SPINE-RACK
 snmp-server community GESH-DC1-RO ro


### PR DESCRIPTION
Makes Arista cEOS eAPI durable across redeploys so the NAPALM Live Lab can collect via the `eos` driver out of the box.

cEOS ships eAPI disabled and its uwsgi backend only spawns at boot, so enabling it in-place is not durable. This adds the eAPI/admin block to the leaf1/leaf4/spine2 startup-configs, so a clean `containerlab deploy` brings up eAPI (HTTPS:443, default VRF).

⚠️ Do not `docker restart` a clab node to enable this — it destroys the veth pairs. Use `containerlab deploy --reconfigure` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable Arista cEOS eAPI by default on selected lab nodes so NAPALM can connect via the eos driver after fresh containerlab deploys.

New Features:
- Preconfigure eAPI (HTTP commands) on leaf1, leaf4, and spine2 cEOS startup-configs to come up enabled on boot.
- Add a default local admin user with network-admin privileges on the affected cEOS nodes for eAPI access.