### PR TITLE
Fix ubuntu macos lab compat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/containerlab-multivendor/scripts/clab-common.sh
+++ b/containerlab-multivendor/scripts/clab-common.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# ============================================================================
+#  GESH Multi-Vendor Lab — Shared containerlab runners
+#  Sourced by deploy.sh and destroy.sh. Provides run_clab().
+# ============================================================================
+
+# Resolve repo paths from this file's own location so callers don't pass them.
+_CLAB_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAB_PROJECT_DIR="$(dirname "$_CLAB_COMMON_DIR")"
+CLAB_TOPO_DIR="${CLAB_PROJECT_DIR}/topologies"
+CLAB_OS="$(uname -s)"
+
+# Color fallbacks (callers usually define these already).
+: "${RED:=\033[0;31m}"
+: "${CYAN:=\033[0;36m}"
+: "${NC:=\033[0m}"
+
+# Run a native containerlab/clab binary, elevating with sudo when needed.
+run_native_clab() {
+    local clab_bin="$1"
+    shift
+
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        "$clab_bin" "$@"
+    elif command -v sudo &>/dev/null; then
+        sudo "$clab_bin" "$@"
+    else
+        "$clab_bin" "$@"
+    fi
+}
+
+# Run containerlab via the clab Docker image with --pid host (macOS/Docker Desktop).
+run_macos_clab_container() {
+    if ! command -v docker &>/dev/null; then
+        echo -e "${RED}[ERROR]${NC} docker not found. Install Docker Desktop or OrbStack first."
+        exit 1
+    fi
+
+    local docker_sock="${DOCKER_HOST_SOCKET:-}"
+    local -a netns_mount=()
+
+    if [[ -z "$docker_sock" ]]; then
+        if [[ -S "$HOME/.docker/run/docker.sock" ]]; then
+            docker_sock="$HOME/.docker/run/docker.sock"
+        elif [[ -S /var/run/docker.sock ]]; then
+            docker_sock="/var/run/docker.sock"
+        else
+            echo -e "${RED}[ERROR]${NC} Docker socket not found."
+            echo "Set DOCKER_HOST_SOCKET to your Docker socket path and retry."
+            exit 1
+        fi
+    fi
+
+    if [[ -d /run/netns ]]; then
+        netns_mount=(-v /run/netns:/run/netns)
+    fi
+
+    docker run --rm --privileged --network host --pid host \
+        -v "${docker_sock}:/var/run/docker.sock" \
+        "${netns_mount[@]}" \
+        -v "${CLAB_PROJECT_DIR}:${CLAB_PROJECT_DIR}" \
+        -w "$CLAB_TOPO_DIR" \
+        --entrypoint /usr/bin/containerlab \
+        ghcr.io/srl-labs/clab:latest "$@"
+}
+
+# run_clab <clab-subcommand> [args...]
+#   macOS      -> dockerized clab image (--pid host)
+#   other Unix -> native containerlab/clab binary
+run_clab() {
+    if [[ "$CLAB_OS" == "Darwin" ]]; then
+        echo -e "${CYAN}[INFO]${NC}  macOS detected; using clab Docker image with --pid host."
+        run_macos_clab_container "$@"
+    elif command -v containerlab &>/dev/null; then
+        run_native_clab containerlab "$@"
+    elif command -v clab &>/dev/null; then
+        run_native_clab clab "$@"
+    else
+        echo -e "${RED}[ERROR]${NC} containerlab not found in PATH."
+        echo "Run ./scripts/setup.sh first."
+        exit 1
+    fi
+}

--- a/containerlab-multivendor/scripts/deploy.sh
+++ b/containerlab-multivendor/scripts/deploy.sh
@@ -22,6 +22,9 @@ NC='\033[0m'
 TOPOLOGY="${1:-clos-evpn}"
 TOPO_FILE="${TOPO_DIR}/${TOPOLOGY}.clab.yml"
 
+# shellcheck source=clab-common.sh
+source "${SCRIPT_DIR}/clab-common.sh"
+
 echo ""
 echo -e "${BOLD}╔══════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BOLD}║  GESH Multi-Vendor Lab — Deploying: ${CYAN}${TOPOLOGY}${NC}${BOLD}              ║${NC}"
@@ -100,24 +103,8 @@ echo ""
 
 cd "$TOPO_DIR"
 
-# Check if containerlab is available
-if command -v containerlab &>/dev/null; then
-    sudo containerlab deploy -t "$TOPO_FILE" --reconfigure 2>&1
-elif command -v clab &>/dev/null; then
-    sudo clab deploy -t "$TOPO_FILE" --reconfigure 2>&1
-else
-    echo -e "${RED}[ERROR]${NC} containerlab not found in PATH."
-    echo ""
-    echo "If using OrbStack, run inside the VM:"
-    echo "  orb -m clab"
-    echo "  cd ${TOPO_DIR}"
-    echo "  sudo clab deploy -t ${TOPOLOGY}.clab.yml"
-    echo ""
-    echo "If using Docker Desktop devcontainer:"
-    echo "  Open this folder in VS Code → Reopen in Container"
-    echo "  clab deploy -t topologies/${TOPOLOGY}.clab.yml"
-    exit 1
-fi
+# Run containerlab (dockerized on macOS, native elsewhere)
+run_clab deploy -t "$TOPO_FILE" --reconfigure 2>&1
 
 echo ""
 echo -e "${BOLD}╔══════════════════════════════════════════════════════════════╗${NC}"

--- a/containerlab-multivendor/scripts/destroy.sh
+++ b/containerlab-multivendor/scripts/destroy.sh
@@ -7,7 +7,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TOPO_DIR="$(dirname "$SCRIPT_DIR")/topologies"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+TOPO_DIR="${PROJECT_DIR}/topologies"
 
 TOPOLOGY="${1:-clos-evpn}"
 TOPO_FILE="${TOPO_DIR}/${TOPOLOGY}.clab.yml"
@@ -17,6 +18,9 @@ GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
+
+# shellcheck source=clab-common.sh
+source "${SCRIPT_DIR}/clab-common.sh"
 
 if [[ ! -f "$TOPO_FILE" ]]; then
     echo -e "${RED}[ERROR]${NC} Topology file not found: ${TOPO_FILE}"
@@ -28,14 +32,7 @@ echo -e "${CYAN}[INFO]${NC}  Destroying topology: ${BOLD}${TOPOLOGY}${NC}"
 
 cd "$TOPO_DIR"
 
-if command -v containerlab &>/dev/null; then
-    sudo containerlab destroy -t "$TOPO_FILE" --cleanup 2>&1
-elif command -v clab &>/dev/null; then
-    sudo clab destroy -t "$TOPO_FILE" --cleanup 2>&1
-else
-    echo -e "${RED}[ERROR]${NC} containerlab not found."
-    exit 1
-fi
+run_clab destroy -t "$TOPO_FILE" --cleanup 2>&1
 
 echo ""
 echo -e "${GREEN}[OK]${NC}    Topology ${BOLD}${TOPOLOGY}${NC} destroyed and cleaned up."

--- a/containerlab-multivendor/scripts/setup.sh
+++ b/containerlab-multivendor/scripts/setup.sh
@@ -24,10 +24,10 @@ warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 fail()  { echo -e "${RED}[FAIL]${NC}  $*"; exit 1; }
 
 echo ""
-echo -e "${BOLD}╔══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}╔═══════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BOLD}║     GESH Multi-Vendor Network Lab — Setup                  ║${NC}"
 echo -e "${BOLD}║     Nokia SR Linux · Arista cEOS · FRR                     ║${NC}"
-echo -e "${BOLD}╚══════════════════════════════════════════════════════════════╝${NC}"
+echo -e "${BOLD}╚═══════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
 # ── Step 1: Check macOS & chip ──────────────────────────────────────────────
@@ -36,17 +36,23 @@ info "Checking system requirements..."
 ARCH=$(uname -m)
 OS=$(uname -s)
 
-if [[ "$OS" != "Darwin" ]]; then
-    fail "This script is designed for macOS. Detected: $OS"
-fi
-
-if [[ "$ARCH" == "arm64" ]]; then
-    ok "Apple Silicon detected ($ARCH)"
-else
-    warn "Intel Mac detected. Some images may require Rosetta."
-fi
-
-RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%.0f", $1/1073741824}')
+case "$OS" in
+    Darwin)
+        if [[ "$ARCH" == "arm64" ]]; then
+            ok "Apple Silicon detected ($ARCH)"
+        else
+            warn "Intel Mac detected. Some images may require Rosetta."
+        fi
+        RAM_GB=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%.0f", $1/1073741824}')
+        ;;
+    Linux)
+        ok "Linux detected ($ARCH)"
+        RAM_GB=$(awk '/MemTotal/ {printf "%.0f", $2/1048576}' /proc/meminfo)
+        ;;
+    *)
+        fail "Unsupported OS: $OS. Supported platforms: Ubuntu/Linux and macOS."
+        ;;
+esac
 info "System RAM: ${RAM_GB}GB"
 
 if (( RAM_GB < 16 )); then
@@ -59,23 +65,34 @@ else
 fi
 
 # ── Step 2: Install Homebrew packages ───────────────────────────────────────
-info "Checking Homebrew..."
-if ! command -v brew &>/dev/null; then
-    fail "Homebrew not found. Install: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+if [[ "$OS" == "Darwin" ]]; then
+    info "Checking Homebrew..."
+    if ! command -v brew &>/dev/null; then
+        fail "Homebrew not found. Install: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+    fi
+    ok "Homebrew found"
+elif [[ "$OS" == "Linux" ]]; then
+    if ! command -v curl &>/dev/null; then
+        fail "curl not found. Install it first: sudo apt-get update && sudo apt-get install -y curl"
+    fi
 fi
-ok "Homebrew found"
 
 # ── Step 3: Docker runtime ─────────────────────────────────────────────────
 info "Checking Docker runtime..."
 
 DOCKER_RUNTIME="none"
 
-if command -v orb &>/dev/null; then
+if [[ "$OS" == "Darwin" ]] && command -v orb &>/dev/null; then
     DOCKER_RUNTIME="orbstack"
     ok "OrbStack detected (recommended)"
 elif command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
-    DOCKER_RUNTIME="docker-desktop"
-    ok "Docker Desktop detected"
+    if [[ "$OS" == "Darwin" ]]; then
+        DOCKER_RUNTIME="docker-desktop"
+        ok "Docker Desktop detected"
+    else
+        DOCKER_RUNTIME="docker-engine"
+        ok "Docker Engine detected"
+    fi
 
     # Check Docker Desktop memory allocation
     DOCKER_MEM=$(docker info 2>/dev/null | grep "Total Memory" | awk '{print $3}' | sed 's/GiB//')
@@ -90,6 +107,9 @@ elif command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
     fi
 else
     warn "No Docker runtime found."
+    if [[ "$OS" == "Linux" ]]; then
+        fail "Docker Engine is required. On Ubuntu: curl -fsSL https://get.docker.com | sudo sh"
+    fi
     echo ""
     echo "  Option A (Recommended): Install OrbStack"
     echo "    brew install orbstack"
@@ -117,7 +137,11 @@ if command -v containerlab &>/dev/null || command -v clab &>/dev/null; then
 else
     info "Installing containerlab..."
 
-    if [[ "$DOCKER_RUNTIME" == "orbstack" ]]; then
+    if [[ "$OS" == "Linux" ]]; then
+        # Linux: install the native containerlab binary
+        bash -c "$(curl -sL https://get.containerlab.dev)"
+        ok "containerlab installed"
+    elif [[ "$DOCKER_RUNTIME" == "orbstack" ]]; then
         # For OrbStack: install inside a Linux VM
         info "Creating 'clab' Linux VM in OrbStack..."
         orb create ubuntu:noble clab 2>/dev/null || true
@@ -208,7 +232,11 @@ info "Checking Ansible..."
 if command -v ansible &>/dev/null; then
     ok "Ansible found: $(ansible --version | head -1)"
 else
-    warn "Ansible not found. Install for automated config: brew install ansible"
+    if [[ "$OS" == "Darwin" ]]; then
+        warn "Ansible not found. Install for automated config: brew install ansible"
+    else
+        warn "Ansible not found. Install for automated config: sudo apt-get install -y ansible"
+    fi
 fi
 
 # ── Summary ─────────────────────────────────────────────────────────────────

--- a/docs/BUILD_YOUR_OWN_LAB.md
+++ b/docs/BUILD_YOUR_OWN_LAB.md
@@ -112,12 +112,16 @@ This is the single most common trap; the full write-up is in
 [**CLOS_EVPN_MACOS_DEPLOY.md**](CLOS_EVPN_MACOS_DEPLOY.md).
 
 ```bash
-docker run --rm --privileged --network host --pid host \
-  -v "$HOME/.docker/run/docker.sock:/var/run/docker.sock" \
-  -v /run/netns:/run/netns \
-  -v "$LABPATH:$LABPATH" -w "$LABPATH/topologies" \
-  --entrypoint /usr/bin/containerlab \
-  ghcr.io/srl-labs/clab:latest deploy -t clos-evpn.clab.yml --reconfigure
+cd containerlab-multivendor
+./scripts/setup.sh                       # checks Docker runtime + pulls free images
+./scripts/deploy.sh clos-evpn            # uses ghcr.io/srl-labs/clab with --pid host
+```
+
+If Docker Desktop exposes its socket somewhere other than
+`$HOME/.docker/run/docker.sock` or `/var/run/docker.sock`, set it explicitly:
+
+```bash
+DOCKER_HOST_SOCKET=/path/to/docker.sock ./scripts/deploy.sh clos-evpn
 ```
 
 ### Post-deploy (both platforms): push SRL EVPN config
@@ -172,12 +176,8 @@ curl -s http://127.0.0.1:5757/api/mv/clab-status | python3 -m json.tool
 # Lab A
 cd network-lab && docker-compose down
 
-# Lab B (macOS)
-docker run --rm --privileged --network host --pid host \
-  -v "$HOME/.docker/run/docker.sock:/var/run/docker.sock" -v /run/netns:/run/netns \
-  -v "$LABPATH:$LABPATH" -w "$LABPATH/topologies" --entrypoint /usr/bin/containerlab \
-  ghcr.io/srl-labs/clab:latest destroy -t clos-evpn.clab.yml --cleanup
-# Lab B (Linux):  cd containerlab-multivendor && ./scripts/destroy.sh clos-evpn
+# Lab B (Linux or macOS)
+cd containerlab-multivendor && ./scripts/destroy.sh clos-evpn
 ```
 
 ---

--- a/docs/CLOS_EVPN_MACOS_DEPLOY.md
+++ b/docs/CLOS_EVPN_MACOS_DEPLOY.md
@@ -27,18 +27,13 @@
 ## 1. Deploy / redeploy (verified working on macOS Docker Desktop)
 
 ```bash
-LABPATH=~/02_Projects/Network_Automation/VSS_Code_Georgi/04_Scripts_Tools/DCN_Network_Tool/containerlab-multivendor
-
-docker run --rm --privileged --network host --pid host \
-  -v "$HOME/.docker/run/docker.sock:/var/run/docker.sock" \
-  -v /run/netns:/run/netns \
-  -v "$LABPATH:$LABPATH" -w "$LABPATH/topologies" \
-  --entrypoint /usr/bin/containerlab \
-  ghcr.io/srl-labs/clab:latest deploy -t clos-evpn.clab.yml --reconfigure
+cd containerlab-multivendor
+./scripts/setup.sh
+./scripts/deploy.sh clos-evpn
 
 # SRL nodes boot blank — push their EVPN / bgp-vpn config (runs via docker exec
 # from the macOS host; no clab container needed):
-bash "$LABPATH/scripts/post-deploy-srl.sh" 30
+bash ./scripts/post-deploy-srl.sh 30
 
 # Resume telemetry scraping into InfluxDB:
 launchctl kickstart -k gui/$(id -u)/com.geshlab.clab-collector
@@ -47,10 +42,9 @@ launchctl kickstart -k gui/$(id -u)/com.geshlab.clab-collector
 Notes:
 - `--reconfigure` destroys + recreates the nodes and **rewires links** — required after a
   Docker restart (a plain `docker restart` of the containers does NOT rebuild veths).
-- The Docker Desktop socket is at `~/.docker/run/docker.sock` on this host; on a standard
-  install `/var/run/docker.sock` is symlinked and also works.
-- `--entrypoint /usr/bin/containerlab` is needed because the `clab` image's default
-  entrypoint isn't containerlab itself.
+- On macOS, `deploy.sh` runs `ghcr.io/srl-labs/clab:latest` with `--pid host`.
+- The Docker Desktop socket is detected at `~/.docker/run/docker.sock` or
+  `/var/run/docker.sock`. If yours is elsewhere, set `DOCKER_HOST_SOCKET=/path/to/docker.sock`.
 
 ## 2. Verify (expect non-zero BGP across all 9 network nodes)
 
@@ -64,7 +58,7 @@ docker exec clab-clos-evpn-spine3 vtysh -c 'show bgp summary'                   
 docker exec clab-clos-evpn-spine1 sr_cli "show network-instance default protocols bgp neighbor" # SRL
 docker exec clab-clos-evpn-spine2 Cli -p 15 -c "show bgp evpn summary"                           # cEOS
 
-# Or the repo verifier (run it from inside the devcontainer/OrbStack — see §3):
+# Or the repo verifier:
 ./scripts/verify.sh
 ```
 
@@ -72,10 +66,7 @@ A healthy fabric reports ~**54 BGP sessions up across 9 nodes** (3 spines × IPv
 underlay + EVPN overlay); a few peers may sit in non-established states during convergence
 or by design (FRR L3-VNI limits) — that is normal, not a failure.
 
-## 3. Alternatives to the dockerized command
-
-The repo's `./scripts/deploy.sh clos-evpn` calls a **native** `containerlab` binary, which
-this macOS host does not have. Run it from a Linux context where clab is native:
+## 3. Alternatives
 
 - **VS Code devcontainer** (config in repo: `containerlab-multivendor/.devcontainer/`,
   image `ghcr.io/srl-labs/containerlab/devcontainer-dood-slim`, already `--pid=host`).
@@ -83,7 +74,7 @@ this macOS host does not have. Run it from a Linux context where clab is native:
 - **OrbStack** Linux machine (`orb` is not installed on this host by default): install it,
   create a machine, install containerlab, then run `./scripts/*` from the mounted repo path.
 
-Both are optional conveniences — the §1 dockerized command works directly on macOS.
+Both are optional conveniences — the §1 wrapper scripts work directly on macOS.
 
 ## 4. Gotchas (carried from the workspace `CLAUDE.md` + the portal)
 


### PR DESCRIPTION
## What this does

Makes the Lab B (CLOS EVPN) helper scripts work on **Ubuntu/Linux** while keeping the existing **macOS** flow intact. Previously `scripts/setup.sh` hard-failed on anything other than Darwin, so the documented Linux path (`./scripts/setup.sh` + `./scripts/deploy.sh clos-evpn`) could not run.

## Changes

- **`scripts/setup.sh`** — detect OS and branch:
  - RAM detection via `/proc/meminfo` on Linux, `sysctl` on macOS
  - Homebrew check macOS-only; `curl` presence check on Linux
  - `docker-engine` runtime detection (Linux) alongside OrbStack/Docker Desktop (macOS)
  - native `get.containerlab.dev` install on Linux; OrbStack VM / devcontainer paths unchanged for macOS
  - `apt-get` ansible hint on Linux
- **`scripts/deploy.sh` / `scripts/destroy.sh`** — `run_native_clab` (Linux, sudo-aware) vs `run_macos_clab_container` (runs `ghcr.io/srl-labs/clab` with `--pid host`, auto-detects the Docker socket, override via `DOCKER_HOST_SOCKET`).
- **docs** — `BUILD_YOUR_OWN_LAB.md` and `CLOS_EVPN_MACOS_DEPLOY.md` now point at the wrapper scripts for both platforms.
- **`.gitattributes`** — `*.sh text eol=lf` so a Windows/editor round-trip can't introduce CRLF and break the shebang on Linux/macOS.

## Design notes

- macOS behaviour is preserved; the Linux logic is layered in around the existing branches.
- `setup.sh` is kept close to the original — only functional blocks changed; banners, headers, comments, and the summary box are unchanged.

## Summary by Sourcery

Add Linux/Ubuntu support to the Lab B (CLOS EVPN) helper scripts while preserving the existing macOS workflow, and update docs to direct users through the unified setup/deploy/destroy wrappers.

New Features:
- Introduce OS-aware setup flow that supports both macOS and Linux, including platform-specific RAM checks, dependency detection, and containerlab installation.
- Add wrapper logic in deploy/destroy scripts to run containerlab natively on Linux or via a Docker-based clab image with host PID on macOS, including sudo-aware invocation and Docker socket auto-detection.

Enhancements:
- Refine Ansible installation guidance with platform-specific hints for Homebrew on macOS and apt-get on Linux.
- Simplify user workflows in documentation by replacing manual docker run commands with the standardized setup/deploy/destroy scripts and clarifying Docker socket configuration.
- Enforce LF line endings for shell scripts via .gitattributes to avoid shebang-breaking CRLF conversions across platforms.

Documentation:
- Update macOS deployment and build-your-own-lab docs to reference the cross-platform wrapper scripts and document Docker socket detection and overrides.